### PR TITLE
Fix filtering of rosbag2 topics

### DIFF
--- a/src/kiss_icp/datasets/rosbag2.py
+++ b/src/kiss_icp/datasets/rosbag2.py
@@ -56,7 +56,10 @@ class RosbagDataset:
         self.topic = topic
         self.check_for_topics()
         self.n_scans = self.bag.topics[self.topic].msgcount
-        self.msgs = self.bag.messages()
+
+        # limit connections to selected topic
+        connections = [x for x in self.bag.connections if x.topic == topic]
+        self.msgs = self.bag.messages(connections=connections)
 
         # Visualization Options
         self.use_global_visualizer = True


### PR DESCRIPTION
Limit the rosbag2 dataloader to only iterate through messages of the selected topic

Fixes #31 