### PR TITLE
Fix pybind and metrics c++17 build

### DIFF
--- a/src/cpp/metrics/CMakeLists.txt
+++ b/src/cpp/metrics/CMakeLists.txt
@@ -26,4 +26,5 @@ target_sources(metrics PRIVATE Metrics.cpp)
 target_include_directories(
   metrics PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
                                                      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_compile_features(metrics PRIVATE cxx_std_17)
 target_link_libraries(metrics PUBLIC Eigen3::Eigen)

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -47,5 +47,6 @@ if(NOT USE_SYSTEM_PYBIND11 OR NOT pybind11_FOUND)
 endif()
 
 pybind11_add_module(kiss_icp_pybind MODULE kiss_icp_pybind.cpp)
+target_compile_features(kiss_icp_pybind PRIVATE cxx_std_17)
 target_link_libraries(kiss_icp_pybind PRIVATE kiss_icp::kiss_icp kiss_icp::metrics)
 install(TARGETS kiss_icp_pybind DESTINATION .)


### PR DESCRIPTION
I've figured out that C++17 compiler settings weren't propagated to `kiss_icp_pybind` and `metrics` targets when build with `-DBUILD_PYTHON_BINDINGS:BOOL=ON` (i.e. `pip install .`)

This is the quick fix aligned with what was done in a MR that restructured things for ROS here https://github.com/PRBonn/kiss-icp/commit/a31f5396c6153f12e9011c9ae6d061597d2f45b3

Because I don't yet have the full picture of the whole build paths such changes maybe not what you had in mind so feel free to reject the MR and add what is working for your current development plang.

However, without propagating/setting C++17 compiler requirements it's compiling with c++11 by default and failing because it's not C++11 standard only code. I know there are thousands of way to add such compiler requirements to CMake/Python builds, so feel free to make it your own way if needed.