### PR TITLE
Visualizer getting slow with big number of poses

### DIFF
--- a/src/python/kiss_icp/datasets/rosbag.py
+++ b/src/python/kiss_icp/datasets/rosbag.py
@@ -69,12 +69,13 @@ class RosbagDataset:
 
         t_field = None
         for field in msg.fields:
-            if field.name == "t" or field.name == "timestamp":
+            if field.name == "t" or field.name == "timestamp" or field.name == "time":
                 t_field = field.name
         timestamps = np.ones(points.shape[0])
         if t_field:
             timestamps = np.array(list(self.pc2.read_points(msg, field_names=t_field)))
-            timestamps = timestamps / np.max(timestamps)
+            if t_field != "time":
+                timestamps = timestamps / np.max(timestamps)
         return points.astype(np.float64), timestamps
 
     def check_for_topics(self):

--- a/src/python/kiss_icp/datasets/rosbag.py
+++ b/src/python/kiss_icp/datasets/rosbag.py
@@ -69,13 +69,12 @@ class RosbagDataset:
 
         t_field = None
         for field in msg.fields:
-            if field.name == "t" or field.name == "timestamp" or field.name == "time":
+            if field.name in ["t", "timestamp", "time"]:
                 t_field = field.name
         timestamps = np.ones(points.shape[0])
         if t_field:
             timestamps = np.array(list(self.pc2.read_points(msg, field_names=t_field)))
-            if t_field != "time":
-                timestamps = timestamps / np.max(timestamps)
+            timestamps = timestamps / np.max(timestamps) if t_field != "time" else timestamps
         return points.astype(np.float64), timestamps
 
     def check_for_topics(self):


### PR DESCRIPTION
When using the visualizer, I found that the pipeline FPS is getting slower as the number of frames increases.

It starts with 25FPS and by the time it goes under 2FPS.

The issue is in **_o3d.geometry.TriangleMesh.create_sphere()_** which is not efficient, so the visualization gets slower as the number of spheres(trajectory poses) increases.

https://github.com/PRBonn/kiss-icp/blob/d848ab891ea6684d41401cc000a6e98eb7f7a3a0/src/python/kiss_icp/tools/visualizer.py#L224-L232

Using rosbags, it takes too long to process a bag when viewing the trajectory.

I am working on a ROS wrapper, this was causing a problem that when the delay increases the pipeline starts to miss messages and the odometry gets crazy.

Using **_o3d.geometry.PointCloud()_** instead solved the issue.
However there a small issue is that all pointclouds in the same open3d window must have the same point size using **_viz.update_geometry()_**.