### PR TITLE
Add options to toggle odom and alias tf

### DIFF
--- a/ros/ros1/OdometryServer.hpp
+++ b/ros/ros1/OdometryServer.hpp
@@ -49,6 +49,7 @@ private:
 
     /// Tools for broadcasting TFs.
     tf2_ros::TransformBroadcaster tf_broadcaster_;
+    bool publish_odom_tf_;
 
     /// Data subscribers.
     ros::Subscriber pointcloud_sub_;


### PR DESCRIPTION
This feature introduces parameters to toggle on/off publishing of TFs to avoid tf conflicts from other sources.

For examples:
- if this were used as an odometry signal in http://wiki.ros.org/robot_localization you need to toggle off the odom->base_link tf
- if not using base link frame_id but the tf already exists (e.g. from robot_state_publisher) do not publish an identity transform