### PR TITLE
Only keep first and last two poses

### DIFF
--- a/ros/ros1/OdometryServer.cpp
+++ b/ros/ros1/OdometryServer.cpp
@@ -110,7 +110,7 @@ void OdometryServer::RegisterFrame(const sensor_msgs::PointCloud2 &msg) {
     const auto &[frame, keypoints] = odometry_.RegisterFrame(points, timestamps);
 
     // PublishPose
-    const auto pose = odometry_.poses().back();
+    const auto pose = odometry_.last_pose();
 
     // Convert from Eigen to ROS types
     const Eigen::Vector3d t_current = pose.translation();

--- a/ros/ros2/OdometryServer.cpp
+++ b/ros/ros2/OdometryServer.cpp
@@ -118,7 +118,7 @@ void OdometryServer::RegisterFrame(const sensor_msgs::msg::PointCloud2::SharedPt
     const auto &[frame, keypoints] = odometry_.RegisterFrame(points, timestamps);
 
     // PublishPose
-    const auto pose = odometry_.poses().back();
+    const auto pose = odometry_.last_pose();
 
     // Convert from Eigen to ROS types
     const Eigen::Vector3d t_current = pose.translation();


### PR DESCRIPTION
This is how the suggestion from #122 could be implemented. Maybe you can think of something even easier. For example, I'm not sure if we really have to keep the first pose in order to determine if we have moved. I tried to retain the existing behavior for now.