### PR TITLE
Fix python pipeline

### DIFF
--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -125,7 +125,7 @@ class OdometryPipeline:
                 for idx in range(len(poses)):
                     tx, ty, tz = poses[idx][:3, -1].flatten()
                     qw, qx, qy, qz = Quaternion(matrix=poses[idx], atol=0.01).elements
-                    tum_data.append([timestamps[idx], tx, ty, tz, qx, qy, qz, qw])
+                    tum_data.append([float(timestamps[idx]), tx, ty, tz, qx, qy, qz, qw])
             return np.array(tum_data).astype(np.float64)
 
         np.savetxt(fname=f"{filename}_tum.txt", X=_to_tum_format(poses, timestamps), fmt="%.4f")


### PR DESCRIPTION
Fix this warning (that for some numpy versions  was an ERROR and lead to a crash):

```
/home/ivizzo/dev/slam/kiss_icp_github/python/kiss_icp/pipeline.py:129: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  return np.array(tum_data).astype(np.float64)
```


Bug introduced in #120 

The problem is that the `timestamps` array had "np.array" inside. Now we cast it to one unique float