### PR TITLE
Fix macOS cibuildwheel

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,7 +1,9 @@
 name: Publish to PyPI.org
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches: ["main"]
+  # release:
+    # types: [published]
 
 jobs:
   build_sdist:
@@ -24,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-11]
+        os: [ubuntu-22.04, windows-2022, macos-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -38,15 +40,15 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-  pypi:
-    needs: [cibuildwheel, build_sdist]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
+  # pypi:
+    # needs: [cibuildwheel, build_sdist]
+    # runs-on: ubuntu-latest
+    # steps:
+      # - uses: actions/download-artifact@v3
+        # with:
+          # name: artifact
+          # path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - uses: pypa/gh-action-pypi-publish@release/v1
+        # with:
+          # password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,9 +1,9 @@
 name: Publish to PyPI.org
 on:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
-  # release:
-    # types: [published]
 
 jobs:
   build_sdist:
@@ -26,12 +26,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-latest]
+        os: [ubuntu-22.04, windows-2022, macos-11]
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build wheels
+      - name: Build test wheels (only PRs)
+        if: github.event_name != 'release'
+        uses: pypa/cibuildwheel@v2.12.0
+        env: # build 1 build per platform just to make sure we can do it later when releasing
+          CIBW_BUILD: "cp310-*"
+        with:
+          package-dir: ${{github.workspace}}/python/
+
+      - name: Build all wheels
+        if: github.event_name == 'release' && github.event.action == 'created'
         uses: pypa/cibuildwheel@v2.12.0
         with:
           package-dir: ${{github.workspace}}/python/
@@ -40,15 +49,16 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-  # pypi:
-    # needs: [cibuildwheel, build_sdist]
-    # runs-on: ubuntu-latest
-    # steps:
-      # - uses: actions/download-artifact@v3
-        # with:
-          # name: artifact
-          # path: dist
+  pypi:
+    if: github.event_name == 'release' && github.event.action == 'created'
+    needs: [cibuildwheel, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
 
-      # - uses: pypa/gh-action-pypi-publish@release/v1
-        # with:
-          # password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, macos-11]
+        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, macos-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, macos-latest]
+        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, macos-11]
 
     steps:
       - uses: actions/checkout@v3

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,4 +21,5 @@ archs = ["auto64"]
 skip = ["*-musllinux*",  "pp*"]
 
 [tool.cibuildwheel.macos]
+environment = "MACOSX_DEPLOYMENT_TARGET=10.14"
 archs = ["auto64", "arm64"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,4 +21,4 @@ archs = ["auto64"]
 skip = ["*-musllinux*",  "pp*"]
 
 [tool.cibuildwheel.macos]
-archs = ["auto64", "universal2"]
+archs = ["auto64", "arm64"]


### PR DESCRIPTION
Bumping the `MACOSX_DEPLOYMENT_TARGET` env variable to one that supports C++17 fix this issue.

More info at: https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/#macos-and-deployment-target-versions

- We also now run 1 cibuildwheel per platform to make sure this doesn't break within PRs
- This also potentially fix #18 . Since we drop the universal2 arch in favor for a more specific one `arm64`