### PR TITLE
Relax cmake requirements

### DIFF
--- a/cpp/kiss_icp/3rdparty/eigen/eigen.cmake
+++ b/cpp/kiss_icp/3rdparty/eigen/eigen.cmake
@@ -24,7 +24,7 @@
 # TODO: Yet another manual release dne by nacho. This should be updated whenever the Eigen team
 # release a new version that is not 3.4. That version does not include this necessary changes:
 # - https://gitlab.com/libeigen/eigen/-/merge_requests/893/diffs
-
+# If you do not have EIGEN installed, the build will fail due the warning comming from the library.
 cmake_minimum_required(VERSION 3.25)
 include(FetchContent)
 FetchContent_Declare(Eigen SYSTEM URL https://github.com/nachovizzo/eigen/archive/refs/tags/3.4.90.tar.gz)

--- a/cpp/kiss_icp/3rdparty/find_dependencies.cmake
+++ b/cpp/kiss_icp/3rdparty/find_dependencies.cmake
@@ -58,3 +58,13 @@ if(NOT USE_SYSTEM_TSLMAP OR NOT TARGET tsl::robin_map)
   set(USE_SYSTEM_TSLMAP OFF)
   include(${CMAKE_CURRENT_LIST_DIR}/tsl_robin/tsl_robin.cmake)
 endif()
+
+# In https://github.com/PRBonn/kiss-icp/pull/129 we introduced the min version of cmake to be 3.25.
+# Nevertheless, in most systems this will still compile. The only problem is when the 3rdparty
+# libraries are not installed on the system, and the SYSTEM flag is not working properly. Therefore
+# all warnings comming for the 3rdparty libaries will be treated as errors and thus, the build will
+# fail.
+if(NOT USE_SYSTEM_TSLMAP OR NOT USE_SYSTEM_SOPHUS AND ${CMAKE_VERSION} VERSION_LESS 3.25)
+  message(WARNING "Please consider to upgrade to CMake>=3.25. You can now easily do this by running\n"
+                  "pip install --upgrade cmake\n")
+endif()

--- a/cpp/kiss_icp/3rdparty/find_dependencies.cmake
+++ b/cpp/kiss_icp/3rdparty/find_dependencies.cmake
@@ -59,11 +59,7 @@ if(NOT USE_SYSTEM_TSLMAP OR NOT TARGET tsl::robin_map)
   include(${CMAKE_CURRENT_LIST_DIR}/tsl_robin/tsl_robin.cmake)
 endif()
 
-# In https://github.com/PRBonn/kiss-icp/pull/129 we introduced the min version of cmake to be 3.25.
-# Nevertheless, in most systems this will still compile. The only problem is when the 3rdparty
-# libraries are not installed on the system, and the SYSTEM flag is not working properly. Therefore
-# all warnings comming for the 3rdparty libaries will be treated as errors and thus, the build will
-# fail.
+# See https://github.com/PRBonn/kiss-icp/pull/129 and https://github.com/PRBonn/kiss-icp/pull/141
 if(NOT USE_SYSTEM_TSLMAP OR NOT USE_SYSTEM_SOPHUS AND ${CMAKE_VERSION} VERSION_LESS 3.25)
   message(WARNING "Please consider to upgrade to CMake>=3.25. You can now easily do this by running\n"
                   "pip install --upgrade cmake\n")

--- a/cpp/kiss_icp/3rdparty/sophus/sophus.cmake
+++ b/cpp/kiss_icp/3rdparty/sophus/sophus.cmake
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # TODO: after https://github.com/strasdat/Sophus/pull/502 gets merged go back to mainstream
-cmake_minimum_required(VERSION 3.25)
 include(FetchContent)
 FetchContent_Declare(Sophus SYSTEM URL https://github.com/nachovizzo/Sophus/archive/refs/tags/1.22.11.tar.gz)
 

--- a/cpp/kiss_icp/3rdparty/tsl_robin/tsl_robin.cmake
+++ b/cpp/kiss_icp/3rdparty/tsl_robin/tsl_robin.cmake
@@ -20,7 +20,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-cmake_minimum_required(VERSION 3.25)
 include(FetchContent)
 FetchContent_Declare(tessil SYSTEM URL https://github.com/Tessil/robin-map/archive/refs/tags/v1.0.1.tar.gz)
 FetchContent_MakeAvailable(tessil)


### PR DESCRIPTION
In #129 we introduced the min version of cmake to be 3.25. Nevertheless, in most systems this will still compile. The only problem is when the 3rdparty libraries are not installed on the system, and the SYSTEM flag is not working properly. Therefore, all warnings coming for the 3rdparty libraries will be treated as errors and thus, the build will fail.

The problem is that when fetching the 3rdparty libraries with cmake, the `SYSTEM` flag is not passed on cmake versions less than 3.25. Therefore, the compiler warnings will produce errors when compiling the KISS-ICP code.

Turns out, that although is not a good practice. Letting Sophus and the robin map library as "user code" does not produce any warning, and thus, no error at build time. This does not hold true for the Eigen library. Lucky us, most of the users that will compile KISS-ICP will have Eigen3 installed by default. Sophus and tsl-robin map can then be fetched at configure time with just a "warning". The warning is there because, at some point, this might end up in a build error.


