### PR TITLE
cibuildwheel does not support Python3.6 anymore thus, we also don't

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,7 @@ max-line-length = "100"
 
 [tool.cibuildwheel]
 archs = ["auto64"]
-skip = ["*-musllinux*",  "pp*"]
+skip = ["*-musllinux*",  "pp*", "cp36-*"]
 
 [tool.cibuildwheel.macos]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.14"


### PR DESCRIPTION
The pipeline started to fail [here](https://github.com/PRBonn/kiss-icp/actions/runs/5468802885). Because of this [breaking change](https://github.com/scikit-build/scikit-build/pull/862)

Therefore we drop support for Python3.6 