### PR TITLE
Expose prediction input in Pipeline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "main"
-    ]
-}

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -39,7 +39,7 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
     const auto prediction = GetPredictionModel();
     const auto last_pose = !poses_.empty() ? poses_.back() : Sophus::SE3d();
     const auto initial_guess = last_pose * prediction;
-    return RegisterFrame(frame, timestamps, initial_guess);                                                
+    return RegisterFrame(frame, timestamps, initial_guess);
 }
 
 KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vector3d> &frame,
@@ -69,7 +69,8 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
     return RegisterFrame(frame, initial_guess);
 }
 
-KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vector3d> &frame, const Sophus::SE3d &initial_guess) {
+KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vector3d> &frame,
+                                                    const Sophus::SE3d &initial_guess) {
     // Preprocess the input cloud
     const auto &cropped_frame = Preprocess(frame, config_.max_range, config_.min_range);
 

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -60,6 +60,13 @@ public:
     KissICP() : KissICP(KISSConfig{}) {}
 
 public:
+
+    Vector3dVectorTuple RegisterFrame(const std::vector<Eigen::Vector3d> &frame,
+                                      const Sophus::SE3d &initial_guess);
+    Vector3dVectorTuple RegisterFrame(const std::vector<Eigen::Vector3d> &frame,
+                                      const std::vector<double> &timestamps,
+                                      const Sophus::SE3d &initial_guess);
+
     Vector3dVectorTuple RegisterFrame(const std::vector<Eigen::Vector3d> &frame);
     Vector3dVectorTuple RegisterFrame(const std::vector<Eigen::Vector3d> &frame,
                                       const std::vector<double> &timestamps);

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -60,7 +60,6 @@ public:
     KissICP() : KissICP(KISSConfig{}) {}
 
 public:
-
     Vector3dVectorTuple RegisterFrame(const std::vector<Eigen::Vector3d> &frame,
                                       const Sophus::SE3d &initial_guess);
     Vector3dVectorTuple RegisterFrame(const std::vector<Eigen::Vector3d> &frame,


### PR DESCRIPTION
In preliminary support (but not exclusively tied to) #183.

This PR allow the Pipeline user to provide an hint/guess of the last transformation, to aid registration of the last cloud with the previous ones. 