### PR TITLE
CHANGED: tbb cmake to make tbb shared lib

### DIFF
--- a/cpp/kiss_icp/3rdparty/tbb/tbb.cmake
+++ b/cpp/kiss_icp/3rdparty/tbb/tbb.cmake
@@ -21,11 +21,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # option(BUILD_SHARED_LIBS ON)
-option(BUILD_SHARED_LIBS OFF)
 option(TBBMALLOC_BUILD OFF)
 option(TBB_EXAMPLES OFF)
 option(TBB_STRICT OFF)
 option(TBB_TEST OFF)
+
+set(BUILD_SHARED_LIBS ON)
 
 include(FetchContent)
 FetchContent_Declare(tbb URL https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.8.0.tar.gz)


### PR DESCRIPTION
will resolve #127 

* The first commit only makes the tbb dynamic library
* Second the .so will be added to pyproject, tho the so is created in a machine specific directory. I need to somehow find a way to give the relative path of to it in a general way 