### PR TITLE
fix kitti rotation error unit

### DIFF
--- a/cpp/kiss_icp/metrics/Metrics.cpp
+++ b/cpp/kiss_icp/metrics/Metrics.cpp
@@ -149,7 +149,7 @@ std::tuple<float, float> SeqError(const std::vector<Eigen::Matrix4d> &poses_gt,
     }
 
     double avg_trans_error = 100.0 * (t_err / static_cast<double>(err.size()));
-    double avg_rot_error = 100.0 * (r_err / static_cast<double>(err.size())) / 3.14 * 180.0;
+    double avg_rot_error = (r_err / static_cast<double>(err.size())) / 3.14 * 180.0;
 
     return std::make_tuple(avg_trans_error, avg_rot_error);
 }

--- a/python/kiss_icp/metrics.py
+++ b/python/kiss_icp/metrics.py
@@ -32,7 +32,7 @@ def sequence_error(
 ) -> Tuple[float, float]:
     """Sptis the sequence error for a given trajectory in camera coordinate frames."""
     ate_kitti, are_kitti = kiss_icp_pybind._kitti_seq_error(gt_poses, results_poses)
-    return ate_kitti, are_kitti/100.
+    return ate_kitti, are_kitti / 100.0
 
 
 def absolute_trajectory_error(

--- a/python/kiss_icp/metrics.py
+++ b/python/kiss_icp/metrics.py
@@ -31,8 +31,7 @@ def sequence_error(
     gt_poses: List[np.ndarray], results_poses: List[np.ndarray]
 ) -> Tuple[float, float]:
     """Sptis the sequence error for a given trajectory in camera coordinate frames."""
-    ate_kitti, are_kitti = kiss_icp_pybind._kitti_seq_error(gt_poses, results_poses)
-    return ate_kitti, are_kitti / 100.0
+    return kiss_icp_pybind._kitti_seq_error(gt_poses, results_poses)
 
 
 def absolute_trajectory_error(

--- a/python/kiss_icp/metrics.py
+++ b/python/kiss_icp/metrics.py
@@ -31,7 +31,8 @@ def sequence_error(
     gt_poses: List[np.ndarray], results_poses: List[np.ndarray]
 ) -> Tuple[float, float]:
     """Sptis the sequence error for a given trajectory in camera coordinate frames."""
-    return kiss_icp_pybind._kitti_seq_error(gt_poses, results_poses)
+    ate_kitti, are_kitti = kiss_icp_pybind._kitti_seq_error(gt_poses, results_poses)
+    return ate_kitti, are_kitti/100.
 
 
 def absolute_trajectory_error(


### PR DESCRIPTION
I found that the unit for average rotation error (kitti metric) might be wrong. 
If `deg/m` is used for average rotation error's unit as [here](https://github.com/PRBonn/kiss-icp/blob/d3bb87caf98229b08fe32a7259845237dc51cbc7/python/kiss_icp/pipeline.py#L174):

```
self.results.append(desc="Average Rotational Error", units="deg/m", value=avg_rot)
```

and according to [here](https://github.com/PRBonn/kiss-icp/blob/main/cpp/kiss_icp/metrics/Metrics.cpp#L152):

```
double avg_rot_error = 100.0 * (r_err / static_cast<double>(err.size())) / 3.14 * 180.0;
```

then the calculated value needs to be divided by 100.