### PR TITLE
Backport tf multisensor fix

### DIFF
--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -47,11 +47,13 @@ if("$ENV{ROS_VERSION}" STREQUAL "1")
     COMPONENTS geometry_msgs
                nav_msgs
                sensor_msgs
+               geometry_msgs
                roscpp
                rosbag
                std_msgs
                tf2
-               tf2_ros)
+               tf2_ros
+               Sophus)
   catkin_package()
 
   # ROS 1 node
@@ -71,6 +73,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
   find_package(rclcpp_components REQUIRED)
   find_package(sensor_msgs REQUIRED)
   find_package(tf2_ros REQUIRED)
+  find_package(sophus REQUIRED)
 
   # ROS 2 node
   add_library(odometry_component SHARED ros2/OdometryServer.cpp)
@@ -84,7 +87,9 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
     rclcpp_components
     nav_msgs
     sensor_msgs
-    tf2_ros)
+    geometry_msgs
+    tf2_ros
+    Sophus)
 
   rclcpp_components_register_node(odometry_component PLUGIN "kiss_icp_ros::OdometryServer" EXECUTABLE odometry_node)
 

--- a/ros/launch/odometry.launch
+++ b/ros/launch/odometry.launch
@@ -21,6 +21,7 @@
     <param name="odom_frame" value="$(arg odom_frame)"/>
     <param name="base_frame" value="$(arg base_frame)"/>
     <param name="publish_odom_tf" value="$(arg publish_odom_tf)"/>
+    <param name="visualize" value="$(arg visualize)"/>
     <!-- KISS-ICP params -->
     <param name="max_range" value="$(arg max_range)"/>
     <param name="min_range" value="$(arg min_range)"/>

--- a/ros/launch/odometry.launch
+++ b/ros/launch/odometry.launch
@@ -4,10 +4,9 @@
   <arg name="bagfile" default=""/>
   <arg name="visualize" default="true"/>
   <arg name="odom_frame" default="odom"/>
-  <arg name="child_frame" default="base_link"/>
+  <arg name="base_frame" default=""/>
   <arg name="topic" default=""/>
-  <arg name="publish_odom_tf" default="true"/>
-  <arg name="publish_alias_tf" default="true"/>
+  <arg name="publish_odom_tf" default="false"/>
 
   <!-- KISS-ICP paramaters -->
   <arg name="deskew" default="false"/>
@@ -20,9 +19,8 @@
     <!-- ROS params -->
     <remap from="pointcloud_topic" to="$(arg topic)"/>
     <param name="odom_frame" value="$(arg odom_frame)"/>
-    <param name="child_frame" value="$(arg child_frame)"/>
+    <param name="base_frame" value="$(arg base_frame)"/>
     <param name="publish_odom_tf" value="$(arg publish_odom_tf)"/>
-    <param name="publish_alias_tf" value="$(arg publish_alias_tf)"/>
     <!-- KISS-ICP params -->
     <param name="max_range" value="$(arg max_range)"/>
     <param name="min_range" value="$(arg min_range)"/>

--- a/ros/package.xml
+++ b/ros/package.xml
@@ -51,6 +51,7 @@
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>sophus</depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/ros/ros1/OdometryServer.cpp
+++ b/ros/ros1/OdometryServer.cpp
@@ -52,10 +52,9 @@ using utils::PointCloud2ToEigen;
 
 OdometryServer::OdometryServer(const ros::NodeHandle &nh, const ros::NodeHandle &pnh)
     : nh_(nh), pnh_(pnh) {
-    pnh_.param("child_frame", child_frame_, child_frame_);
+    pnh_.param("base_frame", base_frame_, base_frame_);
     pnh_.param("odom_frame", odom_frame_, odom_frame_);
-    pnh_.param("publish_alias_tf", publish_alias_tf_, true);
-    pnh_.param("publish_odom_tf", publish_odom_tf_, true);
+    pnh_.param("publish_odom_tf", publish_odom_tf_, false);
     pnh_.param("max_range", config_.max_range, config_.max_range);
     pnh_.param("min_range", config_.min_range, config_.min_range);
     pnh_.param("deskew", config_.deskew, config_.deskew);
@@ -76,101 +75,97 @@ OdometryServer::OdometryServer(const ros::NodeHandle &nh, const ros::NodeHandle 
                                                               &OdometryServer::RegisterFrame, this);
 
     // Initialize publishers
-    odom_publisher_ = pnh_.advertise<nav_msgs::Odometry>("odometry", queue_size_);
-    frame_publisher_ = pnh_.advertise<sensor_msgs::PointCloud2>("frame", queue_size_);
-    kpoints_publisher_ = pnh_.advertise<sensor_msgs::PointCloud2>("keypoints", queue_size_);
-    map_publisher_ = pnh_.advertise<sensor_msgs::PointCloud2>("local_map", queue_size_);
+    odom_publisher_ = pnh_.advertise<nav_msgs::Odometry>("/kiss/odometry", queue_size_);
+    frame_publisher_ = pnh_.advertise<sensor_msgs::PointCloud2>("/kiss/frame", queue_size_);
+    kpoints_publisher_ = pnh_.advertise<sensor_msgs::PointCloud2>("/kiss/keypoints", queue_size_);
+    map_publisher_ = pnh_.advertise<sensor_msgs::PointCloud2>("/kiss/local_map", queue_size_);
+    traj_publisher_ = pnh_.advertise<nav_msgs::Path>("/kiss/trajectory", queue_size_);
 
-    // Initialize trajectory publisher
+    // Initialize the transform broadcaster
+    tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>();
+    tf2_buffer_ = std::make_unique<tf2_ros::Buffer>();
+    tf2_buffer_->setUsingDedicatedThread(true);
+    tf2_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf2_buffer_);
     path_msg_.header.frame_id = odom_frame_;
-    traj_publisher_ = pnh_.advertise<nav_msgs::Path>("trajectory", queue_size_);
-
-    // Broadcast a static transformation that links with identity the specified base link to the
-    // pointcloud_frame, basically to always be able to visualize the frame in rviz
-    if (publish_alias_tf_ && child_frame_ != "base_link") {
-        static tf2_ros::StaticTransformBroadcaster br;
-        geometry_msgs::TransformStamped alias_transform_msg;
-        alias_transform_msg.header.stamp = ros::Time::now();
-        alias_transform_msg.transform.translation.x = 0.0;
-        alias_transform_msg.transform.translation.y = 0.0;
-        alias_transform_msg.transform.translation.z = 0.0;
-        alias_transform_msg.transform.rotation.x = 0.0;
-        alias_transform_msg.transform.rotation.y = 0.0;
-        alias_transform_msg.transform.rotation.z = 0.0;
-        alias_transform_msg.transform.rotation.w = 1.0;
-        alias_transform_msg.header.frame_id = child_frame_;
-        alias_transform_msg.child_frame_id = "base_link";
-        br.sendTransform(alias_transform_msg);
-    }
 
     // publish odometry msg
     ROS_INFO("KISS-ICP ROS 1 Odometry Node Initialized");
 }
 
+Sophus::SE3d OdometryServer::CloudToBaseTf(const std::string &cloud_frame_id) const {
+    std::string err_msg;
+    if (tf2_buffer_->_frameExists(base_frame_) &&     //
+        tf2_buffer_->_frameExists(cloud_frame_id) &&  //
+        tf2_buffer_->canTransform(cloud_frame_id, base_frame_, ros::Time(0), &err_msg)) {
+        try {
+            auto tf = tf2_buffer_->lookupTransform(cloud_frame_id, base_frame_, ros::Time(0));
+            return tf2::transformToSophus(tf);
+        } catch (tf2::TransformException &ex) {
+            ROS_WARN("%s", ex.what());
+        }
+    }
+    ROS_ERROR("Failed to find tf between %s and %s. Reason=%s", 
+        base_frame_.c_str(), cloud_frame_id.c_str(), err_msg.c_str());
+    return {};
+}
+
 void OdometryServer::RegisterFrame(const sensor_msgs::PointCloud2::ConstPtr &msg) {
+    const auto cloud_frame_id = msg->header.frame_id;
     const auto points = PointCloud2ToEigen(msg);
     const auto timestamps = [&]() -> std::vector<double> {
         if (!config_.deskew) return {};
         return GetTimestamps(msg);
     }();
+    const auto egocentric_estimation = (base_frame_.empty() || base_frame_ == cloud_frame_id);
 
     // Register frame, main entry point to KISS-ICP pipeline
     const auto &[frame, keypoints] = odometry_.RegisterFrame(points, timestamps);
 
-    // PublishPose
-    const auto pose = odometry_.poses().back();
+    // Compute the pose using KISS, ego-centric to the LiDAR
+    const Sophus::SE3d kiss_pose = odometry_.poses().back();
 
-    // Convert from Eigen to ROS types
-    const Eigen::Vector3d t_current = pose.translation();
-    const Eigen::Quaterniond q_current = pose.unit_quaternion();
+    // If necessary, transform the ego-centric pose to the specified base_link/base_footprint frame
+    const auto pose = [&]() -> Sophus::SE3d {
+        if (egocentric_estimation) return kiss_pose;
+        const Sophus::SE3d cloud2base = CloudToBaseTf(cloud_frame_id);
+        return cloud2base.inverse() * kiss_pose * cloud2base;
+    }();
+
+    // Header for point clouds and stuff seen from desired odom_frame
+    std_msgs::Header odom_header = msg->header;
+    odom_header.frame_id = odom_frame_;
 
     // Broadcast the tf
     if (publish_odom_tf_) {
         geometry_msgs::TransformStamped transform_msg;
-        transform_msg.header.stamp = msg->header.stamp;
-        transform_msg.header.frame_id = odom_frame_;
-        transform_msg.child_frame_id = child_frame_;
-        transform_msg.transform.rotation.x = q_current.x();
-        transform_msg.transform.rotation.y = q_current.y();
-        transform_msg.transform.rotation.z = q_current.z();
-        transform_msg.transform.rotation.w = q_current.w();
-        transform_msg.transform.translation.x = t_current.x();
-        transform_msg.transform.translation.y = t_current.y();
-        transform_msg.transform.translation.z = t_current.z();
-        tf_broadcaster_.sendTransform(transform_msg);
+        transform_msg.header = odom_header;
+        transform_msg.child_frame_id = egocentric_estimation ? cloud_frame_id : base_frame_;
+        transform_msg.transform = tf2::sophusToTransform(pose);
+        tf_broadcaster_->sendTransform(transform_msg);
     }
 
     // publish trajectory msg
     geometry_msgs::PoseStamped pose_msg;
-    pose_msg.pose.orientation.x = q_current.x();
-    pose_msg.pose.orientation.y = q_current.y();
-    pose_msg.pose.orientation.z = q_current.z();
-    pose_msg.pose.orientation.w = q_current.w();
-    pose_msg.pose.position.x = t_current.x();
-    pose_msg.pose.position.y = t_current.y();
-    pose_msg.pose.position.z = t_current.z();
-    pose_msg.header.stamp = msg->header.stamp;
-    pose_msg.header.frame_id = odom_frame_;
+    pose_msg.header = odom_header;
+    pose_msg.pose = tf2::sophusToPose(pose);
     path_msg_.poses.push_back(pose_msg);
     traj_publisher_.publish(path_msg_);
 
     // publish odometry msg
-    auto odom_msg = std::make_unique<nav_msgs::Odometry>();
-    odom_msg->header = pose_msg.header;
-    odom_msg->child_frame_id = child_frame_;
-    odom_msg->pose.pose = pose_msg.pose;
-    odom_publisher_.publish(*std::move(odom_msg));
+    nav_msgs::Odometry odom_msg;
+    odom_msg.header = odom_header;
+    odom_msg.pose.pose = pose_msg.pose;
+    odom_publisher_.publish(odom_msg);
 
-    // Publish KISS-ICP internal data, just for debugging
-    auto frame_header = msg->header;
-    frame_header.frame_id = child_frame_;
-    frame_publisher_.publish(*std::move(EigenToPointCloud2(frame, frame_header)));
-    kpoints_publisher_.publish(*std::move(EigenToPointCloud2(keypoints, frame_header)));
 
-    // Map is referenced to the odometry_frame
-    auto local_map_header = msg->header;
-    local_map_header.frame_id = odom_frame_;
-    map_publisher_.publish(*std::move(EigenToPointCloud2(odometry_.LocalMap(), local_map_header)));
+    // Publish KISS-ICP internal map, just for debugging
+    const auto kiss_map = odometry_.LocalMap();
+    if (egocentric_estimation) {
+        map_publisher_.publish(*EigenToPointCloud2(kiss_map, odom_header));
+    } else {
+        const auto T = CloudToBaseTf(cloud_frame_id).inverse();
+        map_publisher_.publish(*EigenToPointCloud2(kiss_map, T, odom_header));
+    }
 }
 }  // namespace kiss_icp_ros
 

--- a/ros/ros1/OdometryServer.cpp
+++ b/ros/ros1/OdometryServer.cpp
@@ -76,8 +76,6 @@ OdometryServer::OdometryServer(const ros::NodeHandle &nh, const ros::NodeHandle 
 
     // Initialize publishers
     odom_publisher_ = pnh_.advertise<nav_msgs::Odometry>("/kiss/odometry", queue_size_);
-    frame_publisher_ = pnh_.advertise<sensor_msgs::PointCloud2>("/kiss/frame", queue_size_);
-    kpoints_publisher_ = pnh_.advertise<sensor_msgs::PointCloud2>("/kiss/keypoints", queue_size_);
     map_publisher_ = pnh_.advertise<sensor_msgs::PointCloud2>("/kiss/local_map", queue_size_);
     traj_publisher_ = pnh_.advertise<nav_msgs::Path>("/kiss/trajectory", queue_size_);
 

--- a/ros/ros1/OdometryServer.hpp
+++ b/ros/ros1/OdometryServer.hpp
@@ -32,6 +32,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
+#include <string>
 
 namespace kiss_icp_ros {
 
@@ -44,9 +45,22 @@ private:
     /// Register new frame
     void RegisterFrame(const sensor_msgs::PointCloud2::ConstPtr &msg);
 
-    /// If user ask, report the pose in the given child_frame
-    Sophus::SE3d CloudToBaseTf(const std::string &pointcloud_frame_id) const;
+    /// Stream the estimated pose to ROS
+    void PublishOdometry(const Sophus::SE3d &pose,
+                         const ros::Time &stamp,
+                         const std::string &cloud_frame_id);
 
+    /// Stream the debugging point clouds for visualization (if required)
+    using Vector3dVector = kiss_icp::pipeline::KissICP::Vector3dVector;
+    void PublishClouds(const Vector3dVector frame,
+                       const Vector3dVector keypoints,
+                       const ros::Time &stamp,
+                       const std::string &cloud_frame_id);
+
+    /// Utility function to compute transformation using tf tree
+    Sophus::SE3d LookupTransform(const std::string &target_frame,
+                                 const std::string &source_frame) const;
+    
     /// Ros node stuff
     ros::NodeHandle nh_;
     ros::NodeHandle pnh_;
@@ -57,15 +71,18 @@ private:
     tf2_ros::Buffer tf2_buffer_;
     tf2_ros::TransformListener tf2_listener_;
     bool publish_odom_tf_;
+    bool publish_debug_clouds_;
 
     /// Data subscribers.
     ros::Subscriber pointcloud_sub_;
 
     /// Data publishers.
     ros::Publisher odom_publisher_;
+    ros::Publisher frame_publisher_;
+    ros::Publisher kpoints_publisher_;
+    ros::Publisher map_publisher_;
     ros::Publisher traj_publisher_;
     nav_msgs::Path path_msg_;
-    ros::Publisher map_publisher_;
 
     /// KISS-ICP
     kiss_icp::pipeline::KissICP odometry_;

--- a/ros/ros1/OdometryServer.hpp
+++ b/ros/ros1/OdometryServer.hpp
@@ -29,7 +29,9 @@
 #include <nav_msgs/Path.h>
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
+#include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
 
 namespace kiss_icp_ros {
 
@@ -42,15 +44,19 @@ private:
     /// Register new frame
     void RegisterFrame(const sensor_msgs::PointCloud2::ConstPtr &msg);
 
+    /// If user ask, report the pose in the given child_frame
+    Sophus::SE3d CloudToBaseTf(const std::string &pointcloud_frame_id) const;
+
     /// Ros node stuff
     ros::NodeHandle nh_;
     ros::NodeHandle pnh_;
     int queue_size_{1};
 
     /// Tools for broadcasting TFs.
-    tf2_ros::TransformBroadcaster tf_broadcaster_;
+    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+    std::unique_ptr<tf2_ros::Buffer> tf2_buffer_;
+    std::unique_ptr<tf2_ros::TransformListener> tf2_listener_;
     bool publish_odom_tf_;
-    bool publish_alias_tf_;
 
     /// Data subscribers.
     ros::Subscriber pointcloud_sub_;
@@ -69,7 +75,7 @@ private:
 
     /// Global/map coordinate frame.
     std::string odom_frame_{"odom"};
-    std::string child_frame_{"base_link"};
+    std::string base_frame_{};
 };
 
 }  // namespace kiss_icp_ros

--- a/ros/ros1/OdometryServer.hpp
+++ b/ros/ros1/OdometryServer.hpp
@@ -65,8 +65,6 @@ private:
     ros::Publisher odom_publisher_;
     ros::Publisher traj_publisher_;
     nav_msgs::Path path_msg_;
-    ros::Publisher frame_publisher_;
-    ros::Publisher kpoints_publisher_;
     ros::Publisher map_publisher_;
 
     /// KISS-ICP

--- a/ros/ros1/OdometryServer.hpp
+++ b/ros/ros1/OdometryServer.hpp
@@ -53,9 +53,9 @@ private:
     int queue_size_{1};
 
     /// Tools for broadcasting TFs.
-    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
-    std::unique_ptr<tf2_ros::Buffer> tf2_buffer_;
-    std::unique_ptr<tf2_ros::TransformListener> tf2_listener_;
+    tf2_ros::TransformBroadcaster tf_broadcaster_;
+    tf2_ros::Buffer tf2_buffer_;
+    tf2_ros::TransformListener tf2_listener_;
     bool publish_odom_tf_;
 
     /// Data subscribers.

--- a/ros/ros1/Utils.hpp
+++ b/ros/ros1/Utils.hpp
@@ -27,12 +27,57 @@
 #include <cstddef>
 #include <memory>
 #include <regex>
+#include <sophus/se3.hpp>
 #include <string>
 #include <vector>
 
 // ROS 1 headers
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/Transform.h>
+#include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
+
+
+namespace tf2 {
+
+inline geometry_msgs::Transform sophusToTransform(const Sophus::SE3d &T) {
+    geometry_msgs::Transform t;
+    t.translation.x = T.translation().x();
+    t.translation.y = T.translation().y();
+    t.translation.z = T.translation().z();
+
+    Eigen::Quaterniond q(T.so3().unit_quaternion());
+    t.rotation.x = q.x();
+    t.rotation.y = q.y();
+    t.rotation.z = q.z();
+    t.rotation.w = q.w();
+
+    return t;
+}
+
+inline geometry_msgs::Pose sophusToPose(const Sophus::SE3d &T) {
+    geometry_msgs::Pose t;
+    t.position.x = T.translation().x();
+    t.position.y = T.translation().y();
+    t.position.z = T.translation().z();
+
+    Eigen::Quaterniond q(T.so3().unit_quaternion());
+    t.orientation.x = q.x();
+    t.orientation.y = q.y();
+    t.orientation.z = q.z();
+    t.orientation.w = q.w();
+
+    return t;
+}
+
+inline Sophus::SE3d transformToSophus(const geometry_msgs::TransformStamped &transform) {
+    const auto &t = transform.transform;
+    return Sophus::SE3d(
+        Sophus::SE3d::QuaternionType(t.rotation.w, t.rotation.x, t.rotation.y, t.rotation.z),
+        Sophus::SE3d::Point(t.translation.x, t.translation.y, t.translation.z));
+}
+}  // namespace tf2
 
 namespace kiss_icp_ros::utils {
 using PointCloud2 = sensor_msgs::PointCloud2;
@@ -172,6 +217,16 @@ inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::
 }
 
 inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::Vector3d> &points,
+                                                       const Sophus::SE3d &T,
+                                                       const Header &header) {
+    std::vector<Eigen::Vector3d> points_t;
+    points_t.resize(points.size());
+    std::transform(points.cbegin(), points.cend(), points_t.begin(),
+                   [&](const auto &point) { return T * point; });
+    return EigenToPointCloud2(points_t, header);
+}
+
+inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::Vector3d> &points,
                                                        const std::vector<double> &timestamps,
                                                        const Header &header) {
     auto msg = CreatePointCloud2Msg(points.size(), header, true);
@@ -179,5 +234,4 @@ inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::
     FillPointCloud2Timestamp(timestamps, *msg);
     return msg;
 }
-
 }  // namespace kiss_icp_ros::utils

--- a/ros/rviz/kiss_icp_ros1.rviz
+++ b/ros/rviz/kiss_icp_ros1.rviz
@@ -55,7 +55,7 @@ Visualization Manager:
       Size (Pixels): 1
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /odometry_node/frame
+      Topic: /kiss/frame
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: false
@@ -83,7 +83,7 @@ Visualization Manager:
       Size (Pixels): 1
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /odometry_node/local_map
+      Topic: /kiss/local_map
       Unreliable: true
       Use Fixed Frame: true
       Use rainbow: true
@@ -131,7 +131,7 @@ Visualization Manager:
       Length: 3
       Name: child_frame
       Radius: 0.10000000149011612
-      Reference Frame: base_link
+      Reference Frame: base
       Show Trail: false
       Value: true
     - Alpha: 1
@@ -155,7 +155,7 @@ Visualization Manager:
       Radius: 0.20000000298023224
       Shaft Diameter: 0.10000000149011612
       Shaft Length: 0.10000000149011612
-      Topic: /odometry_node/trajectory
+      Topic: /kiss/trajectory
       Unreliable: false
       Value: true
   Enabled: true


### PR DESCRIPTION
Resolves https://github.com/PRBonn/kiss-icp/issues/244 : backports the changes to the tf buffer from ROS 2 to ROS 1, with the eventual goal of supporting multi-sensor online odometry.

This PR also changes a few minor bugs in the ROS 2 implementation:
- Removes the default base frame from the launch file, which previously confounded the `egocentric_estimation` computation
- Adds Sophus to the package.xml and CMakelists

Please check:

- [x] Memory correctness: the `unique_ptr` usage and move semantics are less idiomatic to ROS 1 than to ROS 2, but I think my implementation is legit
- [x] Default names: we use the absolute `/kiss` namespace preface for our topics, but it might be more idiomatic to just put these nodes in a Namespace group in the launch file
