### PR TITLE
Support Pydantic V2

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,3 +25,7 @@ jobs:
       - name: Test installation
         run: |
           kiss_icp_pipeline --version
+      - name: Run unittests
+        run: |
+          python -m pip install --verbose './python[test]'
+          pytest -rA --verbose ./python/

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ editable:
 	@pip install scikit-build-core pyproject_metadata pathspec pybind11 ninja cmake
 	@pip install --no-build-isolation -ve ./python/
 
+test:
+	@pytest -rA --verbose ./python/
+
 cpp:
 	@cmake -Bbuild cpp/kiss_icp/
 	@cmake --build build -j$(nproc --all)

--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -28,7 +28,6 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from pydantic import PrivateAttr
 from pydantic_settings import BaseSettings
 
 from kiss_icp.config.config import AdaptiveThresholdConfig, DataConfig, MappingConfig

--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -65,7 +65,6 @@ def load_config(
     also specified from the CLI interface"""
 
     config = KISSConfig(**_yaml_source(config_file))
-    print(config.model_dump())
 
     # Override defaults from command line
     if deskew is not None:

--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -28,7 +28,8 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from pydantic import BaseSettings, PrivateAttr
+from pydantic import PrivateAttr
+from pydantic_settings import BaseSettings
 
 from kiss_icp.config.config import AdaptiveThresholdConfig, DataConfig, MappingConfig
 
@@ -38,32 +39,23 @@ class KISSConfig(BaseSettings):
     data: DataConfig = DataConfig()
     mapping: MappingConfig = MappingConfig()
     adaptive_threshold: AdaptiveThresholdConfig = AdaptiveThresholdConfig()
-    _config_file: Optional[Path] = PrivateAttr()
 
-    def __init__(self, config_file: Optional[Path] = None, *args, **kwargs):
-        self._config_file = config_file
-        super().__init__(*args, **kwargs)
 
-    def _yaml_source(self) -> Dict[str, Any]:
-        data = None
-        if self._config_file is not None:
-            try:
-                yaml = importlib.import_module("yaml")
-            except ModuleNotFoundError:
-                print(
-                    "Custom configuration file specified but PyYAML is not installed on your system,"
-                    ' run `pip install "kiss-icp[all]"`. You can also modify the config.py if your '
-                    "system does not support PyYaml "
-                )
-                sys.exit(1)
-            with open(self._config_file) as cfg_file:
-                data = yaml.safe_load(cfg_file)
-        return data or {}
-
-    class Config:
-        @classmethod
-        def customise_sources(cls, init_settings, env_settings, file_secret_settings):
-            return init_settings, KISSConfig._yaml_source
+def _yaml_source(config_file: Optional[Path]) -> Dict[str, Any]:
+    data = None
+    if config_file is not None:
+        try:
+            yaml = importlib.import_module("yaml")
+        except ModuleNotFoundError:
+            print(
+                "Custom configuration file specified but PyYAML is not installed on your system,"
+                ' run `pip install "kiss-icp[all]"`. You can also modify the config.py if your '
+                "system does not support PyYaml "
+            )
+            sys.exit(1)
+        with open(config_file) as cfg_file:
+            data = yaml.safe_load(cfg_file)
+    return data or {}
 
 
 def load_config(
@@ -72,7 +64,8 @@ def load_config(
     """Load configuration from an Optional yaml file. Additionally, deskew and max_range can be
     also specified from the CLI interface"""
 
-    config = KISSConfig(config_file=config_file)
+    config = KISSConfig(**_yaml_source(config_file))
+    print(config.model_dump())
 
     # Override defaults from command line
     if deskew is not None:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
     "natsort",
     "numpy",
     "plyfile",
-    "pydantic <2",
+    "pydantic>=2",
+    "pydantic-settings",
     "pyquaternion",
     "rich",
     "tqdm",
@@ -52,6 +53,9 @@ all = [
     "pyntcloud",
     "PyYAML",
     "trimesh",
+]
+test = [
+    "pytest",
 ]
 visualizer = [
     "open3d>=0.13",
@@ -89,3 +93,6 @@ skip = ["*-musllinux*",  "pp*", "cp36-*"]
 [tool.cibuildwheel.macos]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.14"
 archs = ["auto64", "arm64"]
+
+[tool.pytest.ini_options]
+testpaths = ['tests']

--- a/python/tests/test_kiss_icp.py
+++ b/python/tests/test_kiss_icp.py
@@ -1,0 +1,4 @@
+def test_import():
+    from kiss_icp.kiss_icp import KissICP
+
+    assert KissICP is not None


### PR DESCRIPTION
This updates the code to be compatible with Pydantic V2. We also introduce a smoke test for importing `kiss_icp`. It's still just a smoke test, but does a bit more than only calling `kiss_icp_pipeline --version`. The latter would also pass with Pydantic V2 being installed, while the import would fail.