### PR TITLE
Paint map in global view

### DIFF
--- a/python/kiss_icp/tools/visualizer.py
+++ b/python/kiss_icp/tools/visualizer.py
@@ -33,6 +33,7 @@ YELLOW = np.array([1, 0.706, 0])
 RED = np.array([128, 0, 0]) / 255.0
 BLACK = np.array([0, 0, 0]) / 255.0
 BLUE = np.array([0.4, 0.5, 0.9])
+GRAY = np.array([0.4, 0.4, 0.4])
 SPHERE_SIZE = 0.20
 
 
@@ -216,7 +217,9 @@ class RegistrationVisualizer(StubVisualizer):
         if self.render_map:
             target = copy.deepcopy(target)
             self.target.points = self.o3d.utility.Vector3dVector(target)
-            if not self.global_view:
+            if self.global_view:
+                self.target.paint_uniform_color(GRAY)
+            else:
                 self.target.transform(np.linalg.inv(pose))
         else:
             self.target.points = self.o3d.utility.Vector3dVector()


### PR DESCRIPTION
Solves https://github.com/PRBonn/kiss-icp/issues/268

When using global view, we now paint the map in gray (which can be seen with a black and white background). Even though the default coordinate-based rendering looks better for local map inspection, it will paint the local map black in the global view. In the local view (which should be used to inspect the map) we keep the original rendering.

![image](https://github.com/PRBonn/kiss-icp/assets/38326482/32f86302-61b0-48ce-8441-e2b6ae75d428)

I am also open to other color suggestions or ways to rescale the default colormap :)