### PR TITLE
Improve frame drop robustness

### DIFF
--- a/cpp/kiss_icp/core/Deskew.cpp
+++ b/cpp/kiss_icp/core/Deskew.cpp
@@ -38,11 +38,8 @@ std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &fram
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
                                         const Sophus::SE3d &finish_pose,
-                                        int prev_frame_delta) {
-    if (prev_frame_delta <= 0) {
-	throw std::runtime_error("Math error. prev_frame_delta has to be greater than zero.");
-    }
-    const auto delta_pose = (start_pose.inverse() * finish_pose).log() / prev_frame_delta;
+					double frame_delta_ratio) {
+    const auto delta_pose = (start_pose.inverse() * finish_pose).log() * frame_delta_ratio;
     std::vector<Eigen::Vector3d> corrected_frame(frame.size());
     tbb::parallel_for(size_t(0), frame.size(), [&](size_t i) {
         const auto motion = Sophus::SE3d::exp((timestamps[i] - mid_pose_timestamp) * delta_pose);

--- a/cpp/kiss_icp/core/Deskew.cpp
+++ b/cpp/kiss_icp/core/Deskew.cpp
@@ -37,8 +37,12 @@ namespace kiss_icp {
 std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
-                                        const Sophus::SE3d &finish_pose) {
-    const auto delta_pose = (start_pose.inverse() * finish_pose).log();
+                                        const Sophus::SE3d &finish_pose,
+                                        int prev_frame_delta) {
+    if (prev_frame_delta <= 0) {
+	throw std::runtime_error("Math error. prev_frame_delta has to be greater than zero.");
+    }
+    const auto delta_pose = (start_pose.inverse() * finish_pose).log() / prev_frame_delta;
     std::vector<Eigen::Vector3d> corrected_frame(frame.size());
     tbb::parallel_for(size_t(0), frame.size(), [&](size_t i) {
         const auto motion = Sophus::SE3d::exp((timestamps[i] - mid_pose_timestamp) * delta_pose);

--- a/cpp/kiss_icp/core/Deskew.hpp
+++ b/cpp/kiss_icp/core/Deskew.hpp
@@ -32,6 +32,6 @@ namespace kiss_icp {
 std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
-                                        const Sophus::SE3d &finish_pose);
+                                        const Sophus::SE3d &finish_pose, int prev_frame_delta=1);
 
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Deskew.hpp
+++ b/cpp/kiss_icp/core/Deskew.hpp
@@ -32,6 +32,7 @@ namespace kiss_icp {
 std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
-                                        const Sophus::SE3d &finish_pose, int prev_frame_delta=1);
+                                        const Sophus::SE3d &finish_pose,
+                                        double frame_drop_ratio = 1.0);
 
 }  // namespace kiss_icp

--- a/python/kiss_icp/deskew.py
+++ b/python/kiss_icp/deskew.py
@@ -36,7 +36,7 @@ class StubCompensator:
 
 
 class MotionCompensator:
-    def deskew_scan(self, frame, poses, timestamps):
+    def deskew_scan(self, frame, poses, timestamps, prev_frame_delta = 1):
         if len(poses) < 2:
             return frame
         deskew_frame = kiss_icp_pybind._deskew_scan(
@@ -44,5 +44,6 @@ class MotionCompensator:
             timestamps=timestamps,
             start_pose=poses[-2],
             finish_pose=poses[-1],
+            prev_frame_delta=prev_frame_delta,
         )
         return np.asarray(deskew_frame)

--- a/python/kiss_icp/deskew.py
+++ b/python/kiss_icp/deskew.py
@@ -36,7 +36,7 @@ class StubCompensator:
 
 
 class MotionCompensator:
-    def deskew_scan(self, frame, poses, timestamps, prev_frame_delta = 1):
+    def deskew_scan(self, frame, poses, timestamps, frame_delta_ratio=1.0):
         if len(poses) < 2:
             return frame
         deskew_frame = kiss_icp_pybind._deskew_scan(
@@ -44,6 +44,6 @@ class MotionCompensator:
             timestamps=timestamps,
             start_pose=poses[-2],
             finish_pose=poses[-1],
-            prev_frame_delta=prev_frame_delta,
+            frame_delta_ratio=frame_delta_ratio,
         )
         return np.asarray(deskew_frame)

--- a/python/kiss_icp/kiss_icp.py
+++ b/python/kiss_icp/kiss_icp.py
@@ -42,8 +42,15 @@ class KissICP:
         self.prev_frame_delta = 1
 
     def register_frame(self, frame, timestamps, frame_delta=1):
+        if frame_delta <= 0:
+            raise RuntimeError("Math error. Frame_delta has to be greater than zero.")
+
+        # Handle frame drop case. For better inital pose estimation
+        frame_delta_ratio = frame_delta / self.prev_frame_delta
+
         # Apply motion compensation
-        frame = self.compensator.deskew_scan(frame, self.poses, timestamps, self.prev_frame_delta)
+        frame = self.compensator.deskew_scan(frame, self.poses, timestamps,
+                                             frame_delta_ratio)
 
         # Preprocess the input cloud
         frame = self.preprocess(frame)
@@ -55,7 +62,7 @@ class KissICP:
         sigma = self.get_adaptive_threshold()
 
         # Compute initial_guess for ICP
-        prediction = self.get_prediction_model(frame_delta)
+        prediction = self.get_prediction_model(frame_delta_ratio)
         last_pose = self.poses[-1] if self.poses else np.eye(4)
         initial_guess = last_pose @ prediction
 
@@ -86,11 +93,16 @@ class KissICP:
             else self.adaptive_threshold.get_threshold()
         )
 
-    def get_prediction_model(self, frame_delta):
+    def get_prediction_model(self, frame_delta_ratio=1.0):
         if len(self.poses) < 2:
             return np.eye(4)
         model = np.linalg.inv(self.poses[-2]) @ self.poses[-1]
-        return np.linalg.matrix_power(model, int(frame_delta))
+
+        print("PYTHON ratio round = ", int(round(frame_delta_ratio)))
+        if frame_delta_ratio <= 0.5:
+            return model
+        else:
+            return np.linalg.matrix_power(model, int(round(frame_delta_ratio)))
 
     def has_moved(self):
         if len(self.poses) < 1:

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -103,12 +103,12 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
     m.def(
         "_deskew_scan",
         [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
-           const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish) {
+           const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish, int prev_frame_delta) {
             Sophus::SE3d start_pose(T_start);
             Sophus::SE3d finish_pose(T_finish);
-            return DeSkewScan(frame, timestamps, start_pose, finish_pose);
+            return DeSkewScan(frame, timestamps, start_pose, finish_pose, prev_frame_delta);
         },
-        "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a);
+        "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a, "prev_frame_delta"_a = 1);
 
     // prerpocessing modules
     m.def("_voxel_down_sample", &VoxelDownsample, "frame"_a, "voxel_size"_a);

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -103,12 +103,12 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
     m.def(
         "_deskew_scan",
         [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
-           const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish, int prev_frame_delta) {
+           const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish, float frame_delta_ratio) {
             Sophus::SE3d start_pose(T_start);
             Sophus::SE3d finish_pose(T_finish);
-            return DeSkewScan(frame, timestamps, start_pose, finish_pose, prev_frame_delta);
+            return DeSkewScan(frame, timestamps, start_pose, finish_pose, frame_delta_ratio);
         },
-        "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a, "prev_frame_delta"_a = 1);
+        "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a, "frame_delta_ratio"_a = 1);
 
     // prerpocessing modules
     m.def("_voxel_down_sample", &VoxelDownsample, "frame"_a, "voxel_size"_a);


### PR DESCRIPTION
For real time performance, we may face lidar frame drop cases like the https://github.com/PRBonn/kiss-icp/issues/259 issue.

My chance (for python part only) allows user to pass in the dropped frame number to the algorithm to get a better initial position estimation and a more accurate deskew results.

The main API is self.kiss_icp.register_frame(xyz, ts, frame_delta). frame_delta here is the number of dropped frames of the current register frame. Users can obtain it from the lidar frame ID or adding a frame counter in their code.