### PR TITLE
Fix incorrect installation hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <br />
     <a href=https://user-images.githubusercontent.com/21349875/219626075-d67e9165-31a2-4a1b-8c26-9f04e7d195ec.mp4>Demo</a>
     <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-    <a href="https://github.com/PRBonn/kiss-icp/edit/main/README.md#install">Install</a>
+    <a href="https://github.com/PRBonn/kiss-icp/blob/main/README.md#Install">Install</a>
     <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
     <a href="https://github.com/PRBonn/kiss-icp/blob/main/ros">ROS 1</a>
     <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>


### PR DESCRIPTION
Hello, thanks for operating great works!

This PR fixes an incorrect link in `README.md`.

If a guest user clicks the link below,:

https://github.com/PRBonn/kiss-icp/blob/656bcaeddfb819fa89c32e6c44666d58a3ad6972/README.md?plain=1#L12

then the user has no permission to view, because it's editor mode.

If a normal user clicks the link, then the user would watch the installation markdown script, not the compiled web content.

So, this PR fixes the link from `editor mode` to `viewer mode` like the others.