### PR TITLE
Use .model_dump() because .dict() is outdated

### DIFF
--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -87,6 +87,6 @@ def write_config(config: KISSConfig, filename: str):
     with open(filename, "w") as outfile:
         try:
             yaml = importlib.import_module("yaml")
-            yaml.dump(config.dict(), outfile, default_flow_style=False)
+            yaml.dump(config.model_dump(), outfile, default_flow_style=False)
         except ModuleNotFoundError:
-            outfile.write(str(config.dict()))
+            outfile.write(str(config.model_dump()))


### PR DESCRIPTION
Pydantic is showing a warning, we should use `.model_dump()` as suggested [here](https://docs.pydantic.dev/latest/concepts/serialization/#modelmodel_dump).