### PR TITLE
Remove always True flag

### DIFF
--- a/config/advanced.yaml
+++ b/config/advanced.yaml
@@ -5,7 +5,6 @@ out_dir: "results"
 
 data:
   deskew: True
-  preprocess: True
   max_range: 100.0 # can be also changed in the CLI
   min_range: 0.0
 

--- a/config/basic.yaml
+++ b/config/basic.yaml
@@ -2,7 +2,6 @@ out_dir: "results"
 
 data:
   deskew: False
-  preprocess: True
   max_range: 100.0 # can be also changed in the CLI
   min_range: 5.0
 

--- a/python/kiss_icp/config/config.py
+++ b/python/kiss_icp/config/config.py
@@ -26,7 +26,6 @@ from pydantic import BaseModel
 
 
 class DataConfig(BaseModel):
-    preprocess: bool = True
     max_range: float = 100.0
     min_range: float = 5.0
     deskew: bool = False

--- a/python/kiss_icp/preprocess.py
+++ b/python/kiss_icp/preprocess.py
@@ -27,15 +27,10 @@ from kiss_icp.pybind import kiss_icp_pybind
 
 
 def get_preprocessor(config: KISSConfig):
-    return Preprocessor(config) if config.data.preprocess else Stubcessor()
+    return Preprocessor(config)
 
 
-class Stubcessor:
-    def __call__(self, frame: np.ndarray):
-        return frame
-
-
-class Preprocessor(Stubcessor):
+class Preprocessor:
     def __init__(self, config: KISSConfig):
         self.config = config
 


### PR DESCRIPTION
This also makes the C++ and Python pipelines closer, since C++ has no option to enable/disable preprocessing

I have **no strong** opinions, so we can decide whether to keep this config. I haven't realized that we never use it, as "preprocessing" is just cropping the min/max range of the cloud, so I'd say it is something we always want to do....

Let me know what you guys think