### PR TITLE
Fix and improve ROS visualization

### DIFF
--- a/python/kiss_icp/tools/visualizer.py
+++ b/python/kiss_icp/tools/visualizer.py
@@ -29,7 +29,7 @@ from typing import Callable, List
 
 import numpy as np
 
-YELLOW = np.array([1, 0.706, 0])
+CYAN = np.array([0.24, 0.898, 1])
 RED = np.array([128, 0, 0]) / 255.0
 BLACK = np.array([0, 0, 0]) / 255.0
 BLUE = np.array([0.4, 0.5, 0.9])
@@ -198,7 +198,7 @@ class RegistrationVisualizer(StubVisualizer):
         # Source hot frame
         if self.render_source:
             self.source.points = self.o3d.utility.Vector3dVector(source)
-            self.source.paint_uniform_color(YELLOW)
+            self.source.paint_uniform_color(CYAN)
             if self.global_view:
                 self.source.transform(pose)
         else:
@@ -207,7 +207,7 @@ class RegistrationVisualizer(StubVisualizer):
         # Keypoints
         if self.render_keypoints:
             self.keypoints.points = self.o3d.utility.Vector3dVector(keypoints)
-            self.keypoints.paint_uniform_color(YELLOW)
+            self.keypoints.paint_uniform_color(CYAN)
             if self.global_view:
                 self.keypoints.transform(pose)
         else:

--- a/ros/launch/odometry.launch.py
+++ b/ros/launch/odometry.launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
             DeclareLaunchArgument("visualize", default_value="true"),
             DeclareLaunchArgument("odom_frame", default_value="odom"),
             DeclareLaunchArgument("base_frame", default_value=""),
-            DeclareLaunchArgument("publish_odom_tf", default_value="false"),
+            DeclareLaunchArgument("publish_odom_tf", default_value="true"),
             # KISS-ICP parameters
             DeclareLaunchArgument("deskew", default_value="false"),
             DeclareLaunchArgument("max_range", default_value="100.0"),

--- a/ros/launch/odometry.launch.py
+++ b/ros/launch/odometry.launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
             DeclareLaunchArgument("visualize", default_value="true"),
             DeclareLaunchArgument("odom_frame", default_value="odom"),
             DeclareLaunchArgument("base_frame", default_value=""),
-            DeclareLaunchArgument("publish_odom_tf", default_value="true"),
+            DeclareLaunchArgument("publish_odom_tf", default_value="false"),
             # KISS-ICP parameters
             DeclareLaunchArgument("deskew", default_value="false"),
             DeclareLaunchArgument("max_range", default_value="100.0"),

--- a/ros/rviz/kiss_icp.rviz
+++ b/ros/rviz/kiss_icp.rviz
@@ -23,7 +23,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: frame_deskew
+    SyncSource: ""
 Visualization Manager:
   Class: ""
   Displays:
@@ -38,7 +38,7 @@ Visualization Manager:
           Axis: Z
           Channel Name: intensity
           Class: rviz_default_plugins/PointCloud2
-          Color: 255; 255; 0
+          Color: 61; 229; 255
           Color Transformer: FlatColor
           Decay Time: 0
           Enabled: true
@@ -52,7 +52,7 @@ Visualization Manager:
           Selectable: true
           Size (Pixels): 3
           Size (m): 0.019999999552965164
-          Style: Flat Squares
+          Style: Points
           Topic:
             Depth: 5
             Durability Policy: Volatile
@@ -84,8 +84,8 @@ Visualization Manager:
           Name: kiss_keypoints
           Position Transformer: XYZ
           Selectable: true
-          Size (Pixels): 10
-          Size (m): 1
+          Size (Pixels): 3
+          Size (m): 0.20000000298023224
           Style: Points
           Topic:
             Depth: 5
@@ -100,14 +100,14 @@ Visualization Manager:
         - Alpha: 1
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 98.31531524658203
-            Min Value: 0.6587954163551331
+            Max Value: 14.369325637817383
+            Min Value: 0.20239250361919403
             Value: true
           Axis: Z
           Channel Name: intensity
           Class: rviz_default_plugins/PointCloud2
-          Color: 255; 255; 255
-          Color Transformer: AxisColor
+          Color: 102; 102; 102
+          Color Transformer: FlatColor
           Decay Time: 0
           Enabled: true
           Invert Rainbow: false
@@ -185,7 +185,7 @@ Visualization Manager:
       Value: true
   Enabled: true
   Global Options:
-    Background Color: 48; 48; 48
+    Background Color: 0; 0; 0
     Fixed Frame: odom
     Frame Rate: 30
   Name: root
@@ -229,16 +229,16 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 39.488563537597656
+      Distance: 178.319580078125
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 3.482842445373535
-        Y: 4.3972296714782715
-        Z: 10.242613792419434
+        X: -68.01193237304688
+        Y: 258.05126953125
+        Z: -27.22064781188965
       Focal Shape Fixed Size: false
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false

--- a/ros/rviz/kiss_icp.rviz
+++ b/ros/rviz/kiss_icp.rviz
@@ -202,7 +202,7 @@ Visualization Manager:
             Reliability Policy: Best Effort
             Value: /kiss/trajectory
           Value: true
-      Enabled: true
+      Enabled: false
       Name: odometry
     - Class: rviz_default_plugins/Axes
       Enabled: true

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -71,7 +71,7 @@ using utils::GetTimestamps;
 using utils::PointCloud2ToEigen;
 
 OdometryServer::OdometryServer(const rclcpp::NodeOptions &options)
-    : rclcpp::Node("kiss_icp_node", options) {
+    : rclcpp::Node("odometry_node", options) {
     base_frame_ = declare_parameter<std::string>("base_frame", base_frame_);
     odom_frame_ = declare_parameter<std::string>("odom_frame", odom_frame_);
     publish_odom_tf_ = declare_parameter<bool>("publish_odom_tf", publish_odom_tf_);

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -144,7 +144,7 @@ void OdometryServer::RegisterFrame(const sensor_msgs::msg::PointCloud2::ConstSha
     PublishOdometry(pose, msg->header.stamp, cloud_frame_id);
     // Publishing this clouds is a bit costly, so do it only if we are debugging
     if (publish_debug_clouds_) {
-        PublishClouds(frame, keypoints, msg->header.stamp, cloud_frame_id);
+        PublishClouds(frame, keypoints, msg->header);
     }
 }
 
@@ -179,19 +179,14 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &pose,
 
 void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> frame,
                                    const std::vector<Eigen::Vector3d> keypoints,
-                                   const rclcpp::Time &stamp,
-                                   const std::string &cloud_frame_id) {
-    // debugging happens in an egocentric world
+                                   const std_msgs::msg::Header &header) {
+    // debugging happens in an egocentric world, always
     const auto kiss_map = odometry_.LocalMap();
     const auto kiss_pose = odometry_.poses().back().inverse();
 
-    std_msgs::msg::Header cloud_header;
-    cloud_header.stamp = stamp;
-    cloud_header.frame_id = cloud_frame_id;
-
-    frame_publisher_->publish(std::move(EigenToPointCloud2(frame, cloud_header)));
-    kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, cloud_header)));
-    map_publisher_->publish(std::move(EigenToPointCloud2(kiss_map, kiss_pose, cloud_header)));
+    frame_publisher_->publish(std::move(EigenToPointCloud2(frame, header)));
+    kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, header)));
+    map_publisher_->publish(std::move(EigenToPointCloud2(kiss_map, kiss_pose, header)));
 }
 }  // namespace kiss_icp_ros
 

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -45,6 +45,25 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/string.hpp>
 
+namespace {
+Sophus::SE3d LookupTransform(const std::string &target_frame,
+                             const std::string &source_frame,
+                             const std::unique_ptr<tf2_ros::Buffer> &tf2_buffer) {
+    std::string err_msg;
+    if (tf2_buffer->canTransform(target_frame, source_frame, tf2::TimePointZero, &err_msg)) {
+        try {
+            auto tf = tf2_buffer->lookupTransform(target_frame, source_frame, tf2::TimePointZero);
+            return tf2::transformToSophus(tf);
+        } catch (tf2::TransformException &ex) {
+            RCLCPP_WARN(rclcpp::get_logger("LookupTransform"), "%s", ex.what());
+        }
+    }
+    RCLCPP_WARN(rclcpp::get_logger("LookupTransform"), "Failed to find tf. Reason=%s",
+                err_msg.c_str());
+    return {};
+}
+}  // namespace
+
 namespace kiss_icp_ros {
 
 using utils::EigenToPointCloud2;
@@ -101,23 +120,6 @@ OdometryServer::OdometryServer(const rclcpp::NodeOptions &options)
     RCLCPP_INFO(this->get_logger(), "KISS-ICP ROS 2 odometry node initialized");
 }
 
-Sophus::SE3d OdometryServer::LookupTransform(const std::string &target_frame,
-                                             const std::string &source_frame) const {
-    std::string err_msg;
-    if (tf2_buffer_->_frameExists(source_frame) &&  //
-        tf2_buffer_->_frameExists(target_frame) &&  //
-        tf2_buffer_->canTransform(target_frame, source_frame, tf2::TimePointZero, &err_msg)) {
-        try {
-            auto tf = tf2_buffer_->lookupTransform(target_frame, source_frame, tf2::TimePointZero);
-            return tf2::transformToSophus(tf);
-        } catch (tf2::TransformException &ex) {
-            RCLCPP_WARN(this->get_logger(), "%s", ex.what());
-        }
-    }
-    RCLCPP_WARN(this->get_logger(), "Failed to find tf. Reason=%s", err_msg.c_str());
-    return {};
-}
-
 void OdometryServer::RegisterFrame(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg) {
     const auto cloud_frame_id = msg->header.frame_id;
     const auto points = PointCloud2ToEigen(msg);
@@ -144,7 +146,7 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
     const auto egocentric_estimation = (base_frame_.empty() || base_frame_ == cloud_frame_id);
     const auto pose = [&]() -> Sophus::SE3d {
         if (egocentric_estimation) return kiss_pose;
-        const Sophus::SE3d cloud2base = LookupTransform(base_frame_, cloud_frame_id);
+        const Sophus::SE3d cloud2base = LookupTransform(base_frame_, cloud_frame_id, tf2_buffer_);
         return cloud2base * kiss_pose * cloud2base.inverse();
     }();
 

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -60,7 +60,8 @@ Sophus::SE3d LookupTransform(const std::string &target_frame,
     }
     RCLCPP_WARN(rclcpp::get_logger("LookupTransform"), "Failed to find tf. Reason=%s",
                 err_msg.c_str());
-    return {};
+    // default construction is the identity
+    return Sophus::SE3d();
 }
 }  // namespace
 

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -52,7 +52,7 @@ using utils::GetTimestamps;
 using utils::PointCloud2ToEigen;
 
 OdometryServer::OdometryServer(const rclcpp::NodeOptions &options)
-    : rclcpp::Node("odometry_node", options) {
+    : rclcpp::Node("kiss_icp_node", options) {
     base_frame_ = declare_parameter<std::string>("base_frame", base_frame_);
     odom_frame_ = declare_parameter<std::string>("odom_frame", odom_frame_);
     publish_odom_tf_ = declare_parameter<bool>("publish_odom_tf", publish_odom_tf_);
@@ -169,9 +169,8 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
 void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> frame,
                                    const std::vector<Eigen::Vector3d> keypoints,
                                    const std_msgs::msg::Header &header) {
-    // debugging happens in an egocentric world, always
-    const auto kiss_map = odometry_.LocalMap();
-    const auto kiss_pose = odometry_.poses().back().inverse();
+    const auto kiss_map = kiss_icp_->LocalMap();
+    const auto kiss_pose = kiss_icp_->poses().back().inverse();
 
     frame_publisher_->publish(std::move(EigenToPointCloud2(frame, header)));
     kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, header)));

--- a/ros/src/OdometryServer.hpp
+++ b/ros/src/OdometryServer.hpp
@@ -34,6 +34,7 @@
 #include <nav_msgs/msg/path.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/header.hpp>
 #include <string>
 
 namespace kiss_icp_ros {
@@ -56,8 +57,7 @@ private:
     /// Stream the debugging point clouds for visualization (if required)
     void PublishClouds(const std::vector<Eigen::Vector3d> frame,
                        const std::vector<Eigen::Vector3d> keypoints,
-                       const rclcpp::Time &stamp,
-                       const std::string &cloud_frame_id);
+                       const std_msgs::msg::Header &header);
 
     /// Utility function to compute transformation using tf tree
     Sophus::SE3d LookupTransform(const std::string &target_frame,

--- a/ros/src/OdometryServer.hpp
+++ b/ros/src/OdometryServer.hpp
@@ -56,10 +56,6 @@ private:
                        const std::vector<Eigen::Vector3d> keypoints,
                        const std_msgs::msg::Header &header);
 
-    /// Utility function to compute transformation using tf tree
-    Sophus::SE3d LookupTransform(const std::string &target_frame,
-                                 const std::string &source_frame) const;
-
 private:
     /// Tools for broadcasting TFs.
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;

--- a/ros/src/OdometryServer.hpp
+++ b/ros/src/OdometryServer.hpp
@@ -50,9 +50,7 @@ private:
     void RegisterFrame(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg);
 
     /// Stream the estimated pose to ROS
-    void PublishOdometry(const Sophus::SE3d &pose,
-                         const rclcpp::Time &stamp,
-                         const std::string &cloud_frame_id);
+    void PublishOdometry(const Sophus::SE3d &kiss_pose, const std_msgs::msg::Header &header);
 
     /// Stream the debugging point clouds for visualization (if required)
     void PublishClouds(const std::vector<Eigen::Vector3d> frame,


### PR DESCRIPTION
First of all, now I can finally enjoy reading the implementation. Without the spaghetti if/else/if/else trying to guess which transformation should be applied.

My approach here was to replicate the same as we do in the Python visualizer.:

https://github.com/PRBonn/kiss-icp/blob/44d8563a992b037f3607d328b8815bf41e029e23/python/kiss_icp/tools/visualizer.py#L223

The new logic is as follows:

-  When debugging using ROS, everything happens in an ego-centric world, from the sensor's point of view
- Since the KISS-ICP local map is on the odometric coordinate frame, we need to apply the last ego-centric pose to bring it back to the lidar frame.
- This allowed for further simplification

The only caveat is that, if we DO NOT PUBLISH to the tf tree, then **only** the trajectory will be on a different reference frame and would look odd in the viz. The rest is still fine. Since this is something we never used, need, we don't have in Python, I figured out that's worth disabling it by default.
![image](https://github.com/PRBonn/kiss-icp/assets/21349875/de6d807b-cfd3-4281-86df-e9950e08532a)

The rest I think is all improvement so far

**NOTE** I haven't changed the implementation of KISS, just the visualization utilities for ROS

