### PR TITLE
Prepend `kiss_icp_` for env variable usage

### DIFF
--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -28,12 +28,13 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from kiss_icp.config.config import AdaptiveThresholdConfig, DataConfig, MappingConfig
 
 
 class KISSConfig(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="kiss_icp_")
     out_dir: str = "results"
     data: DataConfig = DataConfig()
     mapping: MappingConfig = MappingConfig()

--- a/python/kiss_icp/tools/cmd.py
+++ b/python/kiss_icp/tools/cmd.py
@@ -114,6 +114,10 @@ $ kiss_icp_pipeline --visualize <path-to-ouster.pcap>:page_facing_up: \[--meta <
 
 # Use a more specific dataloader: {", ".join(_available_dl_help)}
 $ kiss_icp_pipeline --dataloader kitti --sequence 07 --visualize <path-to-kitti-root>:open_file_folder:
+
+# To change single config parameters on-the-fly, you can export them beforehand:
+$ export kiss_icp_out_dir='<path-to-logs>:open_file_folder:'
+$ export kiss_icp_data='{{"max_range": 50}}'
 """
 
 


### PR DESCRIPTION
Before this didn't work
```
export DATA=carlos
kiss_icp_pipeline ...
```

After, you need to be more explicit to break it:
```
export KISS_ICP_DATA=carlos
kiss_icp_pipeline ...
```

This allows us to maintain the API as well