### PR TITLE
Nacho/get rid of get adjacent voxels

### DIFF
--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -65,13 +65,13 @@ std::vector<Voxel> GetAdjacentVoxels(const Voxel &voxel, int adjacent_voxels = 1
 
 Eigen::Vector3d GetClosestNeighbor(const Eigen::Vector3d &point,
                                    const kiss_icp::VoxelHashMap &voxel_map) {
-    // convert the point to voxel coordinates
+    // Convert the point to voxel coordinates
     const Voxel voxel(static_cast<int>(point[0] / voxel_map.voxel_size()),
                       static_cast<int>(point[1] / voxel_map.voxel_size()),
                       static_cast<int>(point[2] / voxel_map.voxel_size()));
-    // Get nearby voxels in the map
+    // Get nearby voxels on the map
     const auto &query_voxels = GetAdjacentVoxels(voxel);
-    // Extract the points containe within the neighboorhod voxels
+    // Extract the points contained within the neighborhood voxels
     const auto &neighbors = voxel_map.GetPoints(query_voxels);
 
     // Find the nearest neighbor

--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -65,13 +65,16 @@ std::vector<Voxel> GetAdjacentVoxels(const Voxel &voxel, int adjacent_voxels = 1
 
 Eigen::Vector3d GetClosestNeighbor(const Eigen::Vector3d &point,
                                    const kiss_icp::VoxelHashMap &voxel_map) {
-    const auto &voxel_size = voxel_map.voxel_size_;
-    const Voxel voxel(static_cast<int>(point[0] / voxel_size),
-                      static_cast<int>(point[1] / voxel_size),
-                      static_cast<int>(point[2] / voxel_size));
-
+    // convert the point to voxel coordinates
+    const Voxel voxel(static_cast<int>(point[0] / voxel_map.voxel_size()),
+                      static_cast<int>(point[1] / voxel_map.voxel_size()),
+                      static_cast<int>(point[2] / voxel_map.voxel_size()));
+    // Get nearby voxels in the map
     const auto &query_voxels = GetAdjacentVoxels(voxel);
+    // Extract the points containe within the neighboorhod voxels
     const auto &neighbors = voxel_map.GetPoints(query_voxels);
+
+    // Find the nearest neighbor
     Eigen::Vector3d closest_neighbor;
     double closest_distance2 = std::numeric_limits<double>::max();
     std::for_each(neighbors.cbegin(), neighbors.cend(), [&](const auto &neighbor) {

--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -66,9 +66,7 @@ std::vector<Voxel> GetAdjacentVoxels(const Voxel &voxel, int adjacent_voxels = 1
 Eigen::Vector3d GetClosestNeighbor(const Eigen::Vector3d &point,
                                    const kiss_icp::VoxelHashMap &voxel_map) {
     // Convert the point to voxel coordinates
-    const Voxel voxel(static_cast<int>(point[0] / voxel_map.voxel_size()),
-                      static_cast<int>(point[1] / voxel_map.voxel_size()),
-                      static_cast<int>(point[2] / voxel_map.voxel_size()));
+    const auto &voxel = voxel_map.PointToVoxel(point);
     // Get nearby voxels on the map
     const auto &query_voxels = GetAdjacentVoxels(voxel);
     // Extract the points contained within the neighborhood voxels

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -31,22 +31,6 @@
 
 namespace kiss_icp {
 
-std::vector<VoxelHashMap::Voxel> VoxelHashMap::GetAdjacentVoxels(const Eigen::Vector3d &point,
-                                                                 int adjacent_voxels) const {
-    auto kx = static_cast<int>(point[0] / voxel_size_);
-    auto ky = static_cast<int>(point[1] / voxel_size_);
-    auto kz = static_cast<int>(point[2] / voxel_size_);
-    std::vector<Voxel> voxel_neighborhood;
-    for (int i = kx - adjacent_voxels; i < kx + adjacent_voxels + 1; ++i) {
-        for (int j = ky - adjacent_voxels; j < ky + adjacent_voxels + 1; ++j) {
-            for (int k = kz - adjacent_voxels; k < kz + adjacent_voxels + 1; ++k) {
-                voxel_neighborhood.emplace_back(i, j, k);
-            }
-        }
-    }
-    return voxel_neighborhood;
-}
-
 std::vector<Eigen::Vector3d> VoxelHashMap::GetPoints(const std::vector<Voxel> &query_voxels) const {
     std::vector<Eigen::Vector3d> points;
     points.reserve(query_voxels.size() * static_cast<size_t>(max_points_per_voxel_));

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -57,7 +57,11 @@ struct VoxelHashMap {
 
     inline void Clear() { map_.clear(); }
     inline bool Empty() const { return map_.empty(); }
-    inline double voxel_size() const { return voxel_size_; }
+    inline Voxel PointToVoxel(const Eigen::Vector3d &point) const {
+        return Voxel(static_cast<int>(point.x() / voxel_size_),
+                     static_cast<int>(point.y() / voxel_size_),
+                     static_cast<int>(point.z() / voxel_size_));
+    }
     void Update(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &origin);
     void Update(const std::vector<Eigen::Vector3d> &points, const Sophus::SE3d &pose);
     void AddPoints(const std::vector<Eigen::Vector3d> &points);

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -57,6 +57,7 @@ struct VoxelHashMap {
 
     inline void Clear() { map_.clear(); }
     inline bool Empty() const { return map_.empty(); }
+    inline double voxel_size() const { return voxel_size_; }
     void Update(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &origin);
     void Update(const std::vector<Eigen::Vector3d> &points, const Sophus::SE3d &pose);
     void AddPoints(const std::vector<Eigen::Vector3d> &points);

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -63,8 +63,6 @@ struct VoxelHashMap {
     void RemovePointsFarFromLocation(const Eigen::Vector3d &origin);
     std::vector<Eigen::Vector3d> Pointcloud() const;
     std::vector<Eigen::Vector3d> GetPoints(const std::vector<Voxel> &query_voxels) const;
-    std::vector<Voxel> GetAdjacentVoxels(const Eigen::Vector3d &point,
-                                         int adjacent_voxels = 1) const;
 
     double voxel_size_;
     double max_distance_;


### PR DESCRIPTION
Follow up from #290 

New result: reads much better
```cpp
Eigen::Vector3d GetClosestNeighbor(const Eigen::Vector3d &point,
                                   const kiss_icp::VoxelHashMap &voxel_map) {
    // Convert the point to voxel coordinates
    const Voxel voxel(static_cast<int>(point[0] / voxel_map.voxel_size()),
                      static_cast<int>(point[1] / voxel_map.voxel_size()),
                      static_cast<int>(point[2] / voxel_map.voxel_size()));
    // Get nearby voxels on the map
    const auto &query_voxels = GetAdjacentVoxels(voxel);
    // Extract the points contained within the neighborhood voxels
    const auto &neighbors = voxel_map.GetPoints(query_voxels);

    // Find the nearest neighbor
    Eigen::Vector3d closest_neighbor;
    double closest_distance2 = std::numeric_limits<double>::max();
    std::for_each(neighbors.cbegin(), neighbors.cend(), [&](const auto &neighbor) {
        double distance = (neighbor - point).squaredNorm();
        if (distance < closest_distance2) {
            closest_neighbor = neighbor;
            closest_distance2 = distance;
        }
    });
    return closest_neighbor;
}
```