### PR TITLE
Create config executable

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -54,6 +54,16 @@ kiss_icp_pipeline --help
 This should print the following help message:
 ![out](https://user-images.githubusercontent.com/21349875/193282970-25a400aa-ebcd-487a-b839-faa04eeca5b9.png)
 
+### Config
+
+You can generate a default `config.yaml` by typing
+
+```sh
+kiss_icp_config
+```
+
+Now, you can modify the parameters and pass the file to the `--config` option when running the `kiss_icp_pipeline`.
+
 ### Install Python API (developer mode)
 
 If you plan to modify the code then you need to setup the dev dependencies, luckily, the only real

--- a/python/README.md
+++ b/python/README.md
@@ -59,7 +59,7 @@ This should print the following help message:
 You can generate a default `config.yaml` by typing
 
 ```sh
-kiss_icp_config
+kiss_icp_dump_config
 ```
 
 Now, you can modify the parameters and pass the file to the `--config` option when running the `kiss_icp_pipeline`.

--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -90,7 +90,7 @@ def load_config(
     return config
 
 
-def write_config(config: KISSConfig, filename: str):
+def write_config(config: KISSConfig = KISSConfig(), filename: str = "config.yaml"):
     with open(filename, "w") as outfile:
         try:
             yaml = importlib.import_module("yaml")

--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -90,7 +90,7 @@ def load_config(
     return config
 
 
-def write_config(config: KISSConfig = KISSConfig(), filename: str = "config.yaml"):
+def write_config(config: KISSConfig = KISSConfig(), filename: str = "kiss_icp.yaml"):
     with open(filename, "w") as outfile:
         try:
             yaml = importlib.import_module("yaml")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -63,6 +63,7 @@ visualizer = [
 
 [project.scripts]
 kiss_icp_pipeline = "kiss_icp.tools.cmd:run"
+kiss_icp_config = "kiss_icp.config.parser:write_config"
 
 [project.urls]
 Homepage = "https://github.com/PRBonn/kiss-icp"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -63,7 +63,7 @@ visualizer = [
 
 [project.scripts]
 kiss_icp_pipeline = "kiss_icp.tools.cmd:run"
-kiss_icp_config = "kiss_icp.config.parser:write_config"
+kiss_icp_dump_config = "kiss_icp.config.parser:write_dump_config"
 
 [project.urls]
 Homepage = "https://github.com/PRBonn/kiss-icp"


### PR DESCRIPTION
This PR adds a new executable `kiss_icp_config` which will dump a `config.yaml` with the default parameters wherever you call it. This makes it a lot easier to run the pipeline from the command line and to play around with the parameters without the need to copy the file from the source code or to remember the parameter names .