### PR TITLE
Use string for sequence

### DIFF
--- a/python/kiss_icp/datasets/kitti.py
+++ b/python/kiss_icp/datasets/kitti.py
@@ -28,7 +28,7 @@ import numpy as np
 
 class KITTIOdometryDataset:
     def __init__(self, data_dir, sequence: str, *_, **__):
-        self.sequence_id = sequence.zfill(2)
+        self.sequence_id = str(sequence).zfill(2)
         self.kitti_sequence_dir = os.path.join(data_dir, "sequences", self.sequence_id)
         self.velodyne_dir = os.path.join(self.kitti_sequence_dir, "velodyne/")
 

--- a/python/kiss_icp/datasets/kitti.py
+++ b/python/kiss_icp/datasets/kitti.py
@@ -27,8 +27,8 @@ import numpy as np
 
 
 class KITTIOdometryDataset:
-    def __init__(self, data_dir, sequence: int, *_, **__):
-        self.sequence_id = str(int(sequence)).zfill(2)
+    def __init__(self, data_dir, sequence: str, *_, **__):
+        self.sequence_id = sequence.zfill(2)
         self.kitti_sequence_dir = os.path.join(data_dir, "sequences", self.sequence_id)
         self.velodyne_dir = os.path.join(self.kitti_sequence_dir, "velodyne/")
 
@@ -36,7 +36,7 @@ class KITTIOdometryDataset:
         self.calibration = self.read_calib_file(os.path.join(self.kitti_sequence_dir, "calib.txt"))
 
         # Load GT Poses (if available)
-        if sequence < 11:
+        if int(sequence) < 11:
             self.poses_fn = os.path.join(data_dir, f"poses/{self.sequence_id}.txt")
             self.gt_poses = self.load_poses(self.poses_fn)
 

--- a/python/kiss_icp/datasets/kitti_raw.py
+++ b/python/kiss_icp/datasets/kitti_raw.py
@@ -43,7 +43,7 @@ __raw_to_odometry_mapping__ = {
 
 class KITTIRawDataset:
     def __init__(self, data_dir: Path, sequence: str, *_, **__):
-        self.sequence_id = sequence.zfill(2)
+        self.sequence_id = str(sequence).zfill(2)
         self.root_dir = os.path.realpath(data_dir / __raw_to_odometry_mapping__[self.sequence_id])
         self.date_id = self.root_dir.split("/")[-2]
         self.valid_idx = self.get_benchmark_indices(self.sequence_id)

--- a/python/kiss_icp/datasets/kitti_raw.py
+++ b/python/kiss_icp/datasets/kitti_raw.py
@@ -28,23 +28,23 @@ from pathlib import Path
 import numpy as np
 
 __raw_to_odometry_mapping__ = {
-    0: "2011_10_03/2011_10_03_drive_0027_sync/",
-    1: "2011_10_03/2011_10_03_drive_0042_sync/",
-    2: "2011_10_03/2011_10_03_drive_0034_sync/",
-    4: "2011_09_30/2011_09_30_drive_0016_sync/",
-    5: "2011_09_30/2011_09_30_drive_0018_sync/",
-    6: "2011_09_30/2011_09_30_drive_0020_sync/",
-    7: "2011_09_30/2011_09_30_drive_0027_sync/",
-    8: "2011_09_30/2011_09_30_drive_0028_sync/",
-    9: "2011_09_30/2011_09_30_drive_0033_sync/",
-    10: "2011_09_30/2011_09_30_drive_0034_sync/",
+    "00": "2011_10_03/2011_10_03_drive_0027_sync/",
+    "01": "2011_10_03/2011_10_03_drive_0042_sync/",
+    "02": "2011_10_03/2011_10_03_drive_0034_sync/",
+    "04": "2011_09_30/2011_09_30_drive_0016_sync/",
+    "05": "2011_09_30/2011_09_30_drive_0018_sync/",
+    "06": "2011_09_30/2011_09_30_drive_0020_sync/",
+    "07": "2011_09_30/2011_09_30_drive_0027_sync/",
+    "08": "2011_09_30/2011_09_30_drive_0028_sync/",
+    "09": "2011_09_30/2011_09_30_drive_0033_sync/",
+    "10": "2011_09_30/2011_09_30_drive_0034_sync/",
 }
 
 
 class KITTIRawDataset:
-    def __init__(self, data_dir: Path, sequence: int, *_, **__):
-        self.sequence_id = str(int(sequence)).zfill(2)
-        self.root_dir = os.path.realpath(data_dir / __raw_to_odometry_mapping__[sequence])
+    def __init__(self, data_dir: Path, sequence: str, *_, **__):
+        self.sequence_id = sequence.zfill(2)
+        self.root_dir = os.path.realpath(data_dir / __raw_to_odometry_mapping__[self.sequence_id])
         self.date_id = self.root_dir.split("/")[-2]
         self.valid_idx = self.get_benchmark_indices(self.sequence_id)
 

--- a/python/kiss_icp/datasets/nuscenes.py
+++ b/python/kiss_icp/datasets/nuscenes.py
@@ -49,7 +49,7 @@ class NuScenesDataset:
         from nuscenes.nuscenes import NuScenes
         from nuscenes.utils.splits import create_splits_logs
 
-        self.sequence_id = sequence.zfill(4)
+        self.sequence_id = str(sequence).zfill(4)
 
         self.nusc = NuScenes(dataroot=str(data_dir), version=nusc_version)
         self.scene_name = f"scene-{self.sequence_id}"

--- a/python/kiss_icp/datasets/nuscenes.py
+++ b/python/kiss_icp/datasets/nuscenes.py
@@ -30,7 +30,7 @@ import numpy as np
 
 
 class NuScenesDataset:
-    def __init__(self, data_dir: Path, sequence: int, *_, **__):
+    def __init__(self, data_dir: Path, sequence: str, *_, **__):
         try:
             importlib.import_module("nuscenes")
         except ModuleNotFoundError:
@@ -49,7 +49,7 @@ class NuScenesDataset:
         from nuscenes.nuscenes import NuScenes
         from nuscenes.utils.splits import create_splits_logs
 
-        self.sequence_id = str(int(sequence)).zfill(4)
+        self.sequence_id = sequence.zfill(4)
 
         self.nusc = NuScenes(dataroot=str(data_dir), version=nusc_version)
         self.scene_name = f"scene-{self.sequence_id}"

--- a/python/kiss_icp/tools/cmd.py
+++ b/python/kiss_icp/tools/cmd.py
@@ -164,7 +164,7 @@ def kiss_icp_pipeline(
         help="[Optional] Open an online visualization of the KISS-ICP pipeline",
         rich_help_panel="Additional Options",
     ),
-    sequence: Optional[int] = typer.Option(
+    sequence: Optional[str] = typer.Option(
         None,
         "--sequence",
         "-s",


### PR DESCRIPTION
I would like to change the sequence parameter to a `str` instead of an `int`. This allows more flexibility when, for example, using a dataset like HeliPR (dataloader coming soon):

![image](https://github.com/PRBonn/kiss-icp/assets/38326482/10f97d16-d5b1-4f1a-be92-d98d12f5bca1)

Here, there are four different sensors available for each recording. With this, we could pass the desired sensor as the sequence parameter:

```
kiss_icp_pipeline --dataloader helipr /path/to/HeLiPR/Roundabout01 -v -s Aeva
```

Passing a KITTI sequence ID will still work (and is anyway internally converted to a string):

```
kiss_icp_pipeline --dataloader kitti /path/to/kitti-odometry/dataset -s 0
```

Otherwise, we have to pass the full path `/path/to/HeLiPR/Roundabout01/LiDAR/Aeva` as `data_dir`, and this becomes messy since the reference poses the dataloader has to read in a parent directory in `/path/to/HeLiPR/Roundabout01/LiDAR_GT`.

What do you guys think @nachovizzo @tizianoGuadagnino?