### PR TITLE
Add more timestamps

### DIFF
--- a/python/kiss_icp/datasets/apollo.py
+++ b/python/kiss_icp/datasets/apollo.py
@@ -49,11 +49,14 @@ class ApolloDataset:
         return len(self.scan_files)
 
     def __getitem__(self, idx):
-        return self.get_scan(self.scan_files[idx])
+        return self.read_point_cloud(self.scan_files[idx])
 
-    def get_scan(self, scan_file: str):
-        points = np.asarray(self.o3d.io.read_point_cloud(scan_file).points, dtype=np.float64)
-        return points.astype(np.float64)
+    def read_point_cloud(self, scan_file: str):
+        pcd = self.o3d.t.io.read_point_cloud(scan_file)
+        points = pcd.point.positions.numpy()
+        timestamps = pcd.point.timestamp.numpy().reshape(-1)
+        timestamps = (timestamps - timestamps.min()) / (timestamps.max() - timestamps.min())
+        return points.astype(np.float64), timestamps
 
     @staticmethod
     def read_poses(file):

--- a/python/kiss_icp/datasets/apollo.py
+++ b/python/kiss_icp/datasets/apollo.py
@@ -49,14 +49,11 @@ class ApolloDataset:
         return len(self.scan_files)
 
     def __getitem__(self, idx):
-        return self.read_point_cloud(self.scan_files[idx])
+        return self.get_scan(self.scan_files[idx])
 
-    def read_point_cloud(self, scan_file: str):
-        pcd = self.o3d.t.io.read_point_cloud(scan_file)
-        points = pcd.point.positions.numpy()
-        timestamps = pcd.point.timestamp.numpy().reshape(-1)
-        timestamps = (timestamps - timestamps.min()) / (timestamps.max() - timestamps.min())
-        return points.astype(np.float64), timestamps
+    def get_scan(self, scan_file: str):
+        points = np.asarray(self.o3d.io.read_point_cloud(scan_file).points, dtype=np.float64)
+        return points.astype(np.float64)
 
     @staticmethod
     def read_poses(file):

--- a/python/kiss_icp/datasets/nclt.py
+++ b/python/kiss_icp/datasets/nclt.py
@@ -54,7 +54,17 @@ class NCLTDataset:
         return len(self.scan_files)
 
     def __getitem__(self, idx):
-        return self.read_point_cloud(os.path.join(self.scans_dir, self.scan_files[idx]))
+        points = self.read_point_cloud(os.path.join(self.scans_dir, self.scan_files[idx]))
+        timestamps = self.get_timestamps(points)
+        return points, timestamps
+
+    @staticmethod
+    def get_timestamps(points):
+        x = points[:, 0]
+        y = points[:, 1]
+        yaw = -np.arctan2(y, x)
+        timestamps = 0.5 * (yaw / np.pi + 1.0)
+        return timestamps
 
     def read_point_cloud(self, file_path: str):
         def _convert(x_s, y_s, z_s):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -58,7 +58,7 @@ test = [
     "pytest",
 ]
 visualizer = [
-    "open3d>=0.13",
+    "open3d>=0.16",
 ]
 
 [project.scripts]


### PR DESCRIPTION
For Apollo, we can switch to using Open3D's tensor library to read the additional attributes from the `pcd.` Note that Apollo is already de-skewed, so it's not needed, but it's nice to have access to it.

NCLT uses a Velodyne-32, so I used the same naive timestamp extraction based on the range image columns as in KITTI raw.

This btw requires Open3d >= 0.16, but I think that should not be a problem.