### PR TITLE
Refactor KissICP pipeline to mantain just 1 pose instead of full trajectory. Fixes #122

### DIFF
--- a/cpp/kiss_icp/core/Deskew.cpp
+++ b/cpp/kiss_icp/core/Deskew.cpp
@@ -36,14 +36,6 @@ constexpr double mid_pose_timestamp{0.5};
 namespace kiss_icp {
 std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
                                         const std::vector<double> &timestamps,
-                                        const Sophus::SE3d &start_pose,
-                                        const Sophus::SE3d &finish_pose) {
-    const auto delta = start_pose.inverse() * finish_pose;
-    return DeSkewScan(frame, timestamps, delta);
-}
-
-std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
-                                        const std::vector<double> &timestamps,
                                         const Sophus::SE3d &delta) {
     const auto delta_pose = delta.log();
     std::vector<Eigen::Vector3d> corrected_frame(frame.size());

--- a/cpp/kiss_icp/core/Deskew.cpp
+++ b/cpp/kiss_icp/core/Deskew.cpp
@@ -38,7 +38,14 @@ std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &fram
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
                                         const Sophus::SE3d &finish_pose) {
-    const auto delta_pose = (start_pose.inverse() * finish_pose).log();
+    const auto delta = start_pose.inverse() * finish_pose;
+    return DeSkewScan(frame, timestamps, delta);
+}
+
+std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
+                                        const std::vector<double> &timestamps,
+                                        const Sophus::SE3d &delta) {
+    const auto delta_pose = delta.log();
     std::vector<Eigen::Vector3d> corrected_frame(frame.size());
     tbb::parallel_for(size_t(0), frame.size(), [&](size_t i) {
         const auto motion = Sophus::SE3d::exp((timestamps[i] - mid_pose_timestamp) * delta_pose);

--- a/cpp/kiss_icp/core/Deskew.hpp
+++ b/cpp/kiss_icp/core/Deskew.hpp
@@ -28,12 +28,7 @@
 
 namespace kiss_icp {
 
-/// Compensate the frame by estimatng the velocity between the given poses
-std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
-                                        const std::vector<double> &timestamps,
-                                        const Sophus::SE3d &start_pose,
-                                        const Sophus::SE3d &finish_pose);
-
+/// Compensate the frame by interpolating the delta pose
 std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &delta);

--- a/cpp/kiss_icp/core/Deskew.hpp
+++ b/cpp/kiss_icp/core/Deskew.hpp
@@ -34,4 +34,8 @@ std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &fram
                                         const Sophus::SE3d &start_pose,
                                         const Sophus::SE3d &finish_pose);
 
+std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
+                                        const std::vector<double> &timestamps,
+                                        const Sophus::SE3d &delta);
+
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -41,7 +41,8 @@ using Matrix6d = Eigen::Matrix<double, 6, 6>;
 using Matrix3_6d = Eigen::Matrix<double, 3, 6>;
 using Vector6d = Eigen::Matrix<double, 6, 1>;
 }  // namespace Eigen
-using Associations = std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>>;
+
+using Correspondences = std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>>;
 using LinearSystem = std::pair<Eigen::Matrix6d, Eigen::Vector6d>;
 
 namespace {
@@ -87,19 +88,19 @@ std::tuple<Eigen::Vector3d, double> GetClosestNeighbor(const Eigen::Vector3d &po
     return std::make_tuple(closest_neighbor, closest_distance);
 }
 
-Associations FindAssociations(const std::vector<Eigen::Vector3d> &points,
-                              const kiss_icp::VoxelHashMap &voxel_map,
-                              double max_correspondance_distance) {
+Correspondences DataAssociation(const std::vector<Eigen::Vector3d> &points,
+                                const kiss_icp::VoxelHashMap &voxel_map,
+                                double max_correspondance_distance) {
     using points_iterator = std::vector<Eigen::Vector3d>::const_iterator;
-    Associations associations;
-    associations.reserve(points.size());
-    associations = tbb::parallel_reduce(
+    Correspondences correspondences;
+    correspondences.reserve(points.size());
+    correspondences = tbb::parallel_reduce(
         // Range
         tbb::blocked_range<points_iterator>{points.cbegin(), points.cend()},
         // Identity
-        associations,
+        correspondences,
         // 1st lambda: Parallel computation
-        [&](const tbb::blocked_range<points_iterator> &r, Associations res) -> Associations {
+        [&](const tbb::blocked_range<points_iterator> &r, Correspondences res) -> Correspondences {
             res.reserve(r.size());
             std::for_each(r.begin(), r.end(), [&](const auto &point) {
                 const auto &[closest_neighbor, distance] = GetClosestNeighbor(point, voxel_map);
@@ -110,17 +111,17 @@ Associations FindAssociations(const std::vector<Eigen::Vector3d> &points,
             return res;
         },
         // 2nd lambda: Parallel reduction
-        [](Associations a, const Associations &b) -> Associations {
+        [](Correspondences a, const Correspondences &b) -> Correspondences {
             a.insert(a.end(),                              //
                      std::make_move_iterator(b.cbegin()),  //
                      std::make_move_iterator(b.cend()));
             return a;
         });
 
-    return associations;
+    return correspondences;
 }
 
-LinearSystem BuildLinearSystem(const Associations &associations, double kernel) {
+LinearSystem BuildLinearSystem(const Correspondences &correspondences, double kernel) {
     auto compute_jacobian_and_residual = [](auto association) {
         const auto &[source, target] = association;
         const Eigen::Vector3d residual = source - target;
@@ -138,14 +139,15 @@ LinearSystem BuildLinearSystem(const Associations &associations, double kernel) 
 
     auto GM_weight = [&](double residual2) { return square(kernel) / square(kernel + residual2); };
 
-    using associations_iterator = Associations::const_iterator;
+    using correspondence_iterator = Correspondences::const_iterator;
     const auto &[JTJ, JTr] = tbb::parallel_reduce(
         // Range
-        tbb::blocked_range<associations_iterator>{associations.cbegin(), associations.cend()},
+        tbb::blocked_range<correspondence_iterator>{correspondences.cbegin(),
+                                                    correspondences.cend()},
         // Identity
         LinearSystem(Eigen::Matrix6d::Zero(), Eigen::Vector6d::Zero()),
         // 1st Lambda: Parallel computation
-        [&](const tbb::blocked_range<associations_iterator> &r, LinearSystem J) -> LinearSystem {
+        [&](const tbb::blocked_range<correspondence_iterator> &r, LinearSystem J) -> LinearSystem {
             return std::transform_reduce(
                 r.begin(), r.end(), J, sum_linear_systems, [&](const auto &association) {
                     const auto &[J_r, residual] = compute_jacobian_and_residual(association);
@@ -177,8 +179,8 @@ Registration::Registration(int max_num_iteration, double convergence_criterion, 
 Sophus::SE3d Registration::AlignPointsToMap(const std::vector<Eigen::Vector3d> &frame,
                                             const VoxelHashMap &voxel_map,
                                             const Sophus::SE3d &initial_guess,
-                                            double max_correspondence_distance,
-                                            double kernel) {
+                                            double max_distance,
+                                            double kernel_scale) {
     if (voxel_map.Empty()) return initial_guess;
 
     // Equation (9)
@@ -189,9 +191,9 @@ Sophus::SE3d Registration::AlignPointsToMap(const std::vector<Eigen::Vector3d> &
     Sophus::SE3d T_icp = Sophus::SE3d();
     for (int j = 0; j < max_num_iterations_; ++j) {
         // Equation (10)
-        const auto associations = FindAssociations(source, voxel_map, max_correspondence_distance);
+        const auto correspondences = DataAssociation(source, voxel_map, max_distance);
         // Equation (11)
-        const auto &[JTJ, JTr] = BuildLinearSystem(associations, kernel);
+        const auto &[JTJ, JTr] = BuildLinearSystem(correspondences, kernel_scale);
         const Eigen::Vector6d dx = JTJ.ldlt().solve(-JTr);
         const Sophus::SE3d estimation = Sophus::SE3d::exp(dx);
         // Equation (12)

--- a/cpp/kiss_icp/core/Registration.hpp
+++ b/cpp/kiss_icp/core/Registration.hpp
@@ -36,8 +36,8 @@ struct Registration {
     Sophus::SE3d AlignPointsToMap(const std::vector<Eigen::Vector3d> &frame,
                                   const VoxelHashMap &voxel_map,
                                   const Sophus::SE3d &initial_guess,
-                                  double max_correspondence_distance,
-                                  double kernel);
+                                  const double max_correspondence_distance,
+                                  const double kernel_scale);
 
     int max_num_iterations_;
     double convergence_criterion_;

--- a/cpp/kiss_icp/core/Threshold.cpp
+++ b/cpp/kiss_icp/core/Threshold.cpp
@@ -42,10 +42,6 @@ double AdaptiveThreshold::ComputeThreshold() {
         model_error_sse2_ += model_error * model_error;
         num_samples_++;
     }
-
-    if (num_samples_ < 1) {
-        return initial_threshold_;
-    }
     return std::sqrt(model_error_sse2_ / num_samples_);
 }
 

--- a/cpp/kiss_icp/core/Threshold.cpp
+++ b/cpp/kiss_icp/core/Threshold.cpp
@@ -25,24 +25,29 @@
 #include <Eigen/Core>
 #include <cmath>
 
-namespace {
-double ComputeModelError(const Sophus::SE3d &model_deviation, double max_range) {
-    const double theta = Eigen::AngleAxisd(model_deviation.rotationMatrix()).angle();
-    const double delta_rot = 2.0 * max_range * std::sin(theta / 2.0);
-    const double delta_trans = model_deviation.translation().norm();
-    return delta_trans + delta_rot;
-}
-}  // namespace
-
 namespace kiss_icp {
+AdaptiveThreshold::AdaptiveThreshold(double initial_threshold,
+                                     double min_motion_threshold,
+                                     double max_range)
+    : min_motion_threshold_(min_motion_threshold),
+      max_range_(max_range),
+      model_sse_(initial_threshold * initial_threshold),
+      model_error_(0.0),
+      num_samples_(1) {}
+
+void AdaptiveThreshold::UpdateModelDeviation(const Sophus::SE3d &current_deviation) {
+    const double theta = Eigen::AngleAxisd(current_deviation.rotationMatrix()).angle();
+    const double delta_rot = 2.0 * max_range_ * std::sin(theta / 2.0);
+    const double delta_trans = current_deviation.translation().norm();
+    model_error_ = delta_trans + delta_rot;
+}
 
 double AdaptiveThreshold::ComputeThreshold() {
-    double model_error = ComputeModelError(model_deviation_, max_range_);
-    if (model_error > min_motion_th_) {
-        model_error_sse2_ += model_error * model_error;
+    if (model_error_ > min_motion_threshold_) {
+        model_sse_ += model_error_ * model_error_;
         num_samples_++;
     }
-    return std::sqrt(model_error_sse2_ / num_samples_);
+    return std::sqrt(model_sse_ / num_samples_);
 }
 
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Threshold.hpp
+++ b/cpp/kiss_icp/core/Threshold.hpp
@@ -35,7 +35,7 @@ struct AdaptiveThreshold {
     void UpdateModelDeviation(const Sophus::SE3d &current_deviation);
 
     /// Returns the KISS-ICP adaptive threshold used in registration
-    double ComputeThreshold();
+    constexpr double ComputeThreshold() const { return std::sqrt(model_sse_ / num_samples_); }
 
     // configurable parameters
     double min_motion_threshold_;
@@ -43,7 +43,6 @@ struct AdaptiveThreshold {
 
     // Local cache for ccomputation
     double model_sse_;
-    double model_error_;
     int num_samples_;
 };
 

--- a/cpp/kiss_icp/core/Threshold.hpp
+++ b/cpp/kiss_icp/core/Threshold.hpp
@@ -27,28 +27,24 @@
 namespace kiss_icp {
 
 struct AdaptiveThreshold {
-    explicit AdaptiveThreshold(double initial_threshold, double min_motion_th, double max_range)
-        : min_motion_th_(min_motion_th),
-          max_range_(max_range),
-          model_error_sse2_(initial_threshold * initial_threshold),
-          num_samples_(1) {}
+    explicit AdaptiveThreshold(double initial_threshold,
+                               double min_motion_threshold,
+                               double max_range);
 
     /// Update the current belief of the deviation from the prediction model
-    inline void UpdateModelDeviation(const Sophus::SE3d &current_deviation) {
-        model_deviation_ = current_deviation;
-    }
+    void UpdateModelDeviation(const Sophus::SE3d &current_deviation);
 
     /// Returns the KISS-ICP adaptive threshold used in registration
     double ComputeThreshold();
 
     // configurable parameters
-    double min_motion_th_;
+    double min_motion_threshold_;
     double max_range_;
 
     // Local cache for ccomputation
-    double model_error_sse2_;
+    double model_sse_;
+    double model_error_;
     int num_samples_;
-    Sophus::SE3d model_deviation_ = Sophus::SE3d();
 };
 
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Threshold.hpp
+++ b/cpp/kiss_icp/core/Threshold.hpp
@@ -35,7 +35,7 @@ struct AdaptiveThreshold {
     void UpdateModelDeviation(const Sophus::SE3d &current_deviation);
 
     /// Returns the KISS-ICP adaptive threshold used in registration
-    constexpr double ComputeThreshold() const { return std::sqrt(model_sse_ / num_samples_); }
+    double ComputeThreshold() const { return std::sqrt(model_sse_ / num_samples_); }
 
     // configurable parameters
     double min_motion_threshold_;

--- a/cpp/kiss_icp/core/Threshold.hpp
+++ b/cpp/kiss_icp/core/Threshold.hpp
@@ -28,9 +28,10 @@ namespace kiss_icp {
 
 struct AdaptiveThreshold {
     explicit AdaptiveThreshold(double initial_threshold, double min_motion_th, double max_range)
-        : initial_threshold_(initial_threshold),
-          min_motion_th_(min_motion_th),
-          max_range_(max_range) {}
+        : min_motion_th_(min_motion_th),
+          max_range_(max_range),
+          model_error_sse2_(initial_threshold * initial_threshold),
+          num_samples_(1) {}
 
     /// Update the current belief of the deviation from the prediction model
     inline void UpdateModelDeviation(const Sophus::SE3d &current_deviation) {
@@ -41,13 +42,12 @@ struct AdaptiveThreshold {
     double ComputeThreshold();
 
     // configurable parameters
-    double initial_threshold_;
     double min_motion_th_;
     double max_range_;
 
     // Local cache for ccomputation
-    double model_error_sse2_ = 0;
-    int num_samples_ = 0;
+    double model_error_sse2_;
+    int num_samples_;
     Sophus::SE3d model_deviation_ = Sophus::SE3d();
 };
 

--- a/cpp/kiss_icp/core/Threshold.hpp
+++ b/cpp/kiss_icp/core/Threshold.hpp
@@ -35,7 +35,7 @@ struct AdaptiveThreshold {
     void UpdateModelDeviation(const Sophus::SE3d &current_deviation);
 
     /// Returns the KISS-ICP adaptive threshold used in registration
-    double ComputeThreshold() const { return std::sqrt(model_sse_ / num_samples_); }
+    inline double ComputeThreshold() const { return std::sqrt(model_sse_ / num_samples_); }
 
     // configurable parameters
     double min_motion_threshold_;

--- a/cpp/kiss_icp/metrics/Metrics.cpp
+++ b/cpp/kiss_icp/metrics/Metrics.cpp
@@ -172,17 +172,14 @@ std::tuple<float, float> AbsoluteTrajectoryError(const std::vector<Eigen::Matrix
     for (size_t j = 0; j < num_poses; ++j) {
         // Apply alignement matrix
         const Eigen::Matrix4d T_estimate = T_align_trajectories * poses_result[j];
-        const Eigen::Matrix4d &T_ground_truth = poses_gt[j];
-        // Compute error in translation and rotation matrix (ungly)
-        const Eigen::Matrix3d delta_R =
-            T_ground_truth.block<3, 3>(0, 0) * T_estimate.block<3, 3>(0, 0).transpose();
-        const Eigen::Vector3d delta_t =
-            T_ground_truth.block<3, 1>(0, 3) - delta_R * T_estimate.block<3, 1>(0, 3);
+        const Eigen::Matrix4d T_ground_truth = poses_gt[j];
+        const auto delta_T = T_estimate.inverse() * T_ground_truth;
         // Get angular error
-        const double theta = Eigen::AngleAxisd(delta_R).angle();
+        const double delta_theta = Eigen::AngleAxisd(delta_T.block<3, 3>(0, 0)).angle();
+        const auto delta_trans = delta_T.block<3, 1>(0, 3);
         // Sum of Squares
-        ATE_rot += theta * theta;
-        ATE_trans += delta_t.squaredNorm();
+        ATE_rot += delta_theta * delta_theta;
+        ATE_trans += delta_trans.squaredNorm();
     }
     // Get the RMSE
     ATE_rot /= static_cast<double>(num_poses);

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -51,7 +51,7 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
     const auto &[source, frame_downsample] = Voxelize(cropped_frame);
 
     // Get motion prediction and adaptive_threshold
-    const double sigma = GetAdaptiveThreshold();
+    const double sigma = adaptive_threshold_.ComputeThreshold();
 
     // Compute initial_guess for ICP
     const auto initial_guess = last_pose_ * last_prediction_;
@@ -76,9 +76,5 @@ KissICP::Vector3dVectorTuple KissICP::Voxelize(const std::vector<Eigen::Vector3d
     const auto source = kiss_icp::VoxelDownsample(frame_downsample, voxel_size * 1.5);
     return {source, frame_downsample};
 }
-
-double KissICP::GetAdaptiveThreshold() { return adaptive_threshold_.ComputeThreshold(); }
-
-bool KissICP::HasMoved() { return true; }
 
 }  // namespace kiss_icp::pipeline

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -49,7 +49,7 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
     // Voxelize
     const auto &[source, frame_downsample] = Voxelize(cropped_frame);
 
-    // Get motion prediction and adaptive_threshold
+    // Get adaptive_threshold
     const double sigma = adaptive_threshold_.ComputeThreshold();
 
     // Compute initial_guess for ICP
@@ -58,7 +58,7 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
     // Save current pose before the ICP loop to compute the current_delta_ later
     const auto last_pose = current_pose_;
 
-    // Run ICP and update the current estimation
+    // Run ICP
     const auto new_pose = registration_.AlignPointsToMap(source,         // frame
                                                          local_map_,     // voxel_map
                                                          initial_guess,  // initial_guess

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -23,6 +23,7 @@
 
 #include <Eigen/Core>
 #include <deque>
+#include <sophus/se3.hpp>
 #include <tuple>
 #include <vector>
 
@@ -58,16 +59,6 @@ public:
     using Vector3dVector = std::vector<Eigen::Vector3d>;
     using Vector3dVectorTuple = std::tuple<Vector3dVector, Vector3dVector>;
 
-    /// Template class to avoid growing infinitely the number of poses_
-    struct PosesSlidingWindow {
-        inline void updatePose(const Sophus::SE3d &pose) {
-            std::swap(last_pose, before_last_pose);
-            last_pose = pose;
-        }
-        Sophus::SE3d last_pose;
-        Sophus::SE3d before_last_pose;
-    };
-
 public:
     explicit KissICP(const KISSConfig &config)
         : config_(config),
@@ -88,11 +79,11 @@ public:
 public:
     // Extra C++ API to facilitate ROS debugging
     std::vector<Eigen::Vector3d> LocalMap() const { return local_map_.Pointcloud(); };
-    // std::vector<Sophus::SE3d> poses() const { return poses_; };
 
 private:
     // KISS-ICP pipeline modules
-    PosesSlidingWindow poses_;
+    Sophus::SE3d last_pose_;
+    Sophus::SE3d last_delta_;
     KISSConfig config_;
     Registration registration_;
     VoxelHashMap local_map_;

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -74,12 +74,14 @@ public:
     Vector3dVectorTuple Voxelize(const std::vector<Eigen::Vector3d> &frame) const;
 
     std::vector<Eigen::Vector3d> LocalMap() const { return local_map_.Pointcloud(); };
-    Sophus::SE3d CurrentPose() const { return last_pose_; }
+    Sophus::SE3d pose() const { return current_pose_; }
+    Sophus::SE3d delta() const { return current_pose_; }
 
 private:
+    Sophus::SE3d current_pose_;
+    Sophus::SE3d current_delta_;
+
     // KISS-ICP pipeline modules
-    Sophus::SE3d last_pose_;
-    Sophus::SE3d last_prediction_;
     KISSConfig config_;
     Registration registration_;
     VoxelHashMap local_map_;

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -59,22 +59,13 @@ public:
     using Vector3dVectorTuple = std::tuple<Vector3dVector, Vector3dVector>;
 
     /// Template class to avoid growing infinitely the number of poses_
-    template <typename T, std::size_t MAX_SIZE = 2>
-    struct fixed_size_vector {
-        void push_back(const T &elem) {
-            if (deque_.size() == MAX_SIZE) deque_.pop_front();
-            deque_.push_back(elem);
+    struct PosesSlidingWindow {
+        inline void updatePose(const Sophus::SE3d &pose) {
+            std::swap(last_pose, before_last_pose);
+            last_pose = pose;
         }
-        operator std::vector<T>() const { return std::vector<T>(deque_.begin(), deque_.end()); }
-        auto empty() const { return deque_.empty(); }
-        auto size() const { return deque_.size(); }
-        const auto &front() const { return deque_.front(); }
-        auto &front() { return deque_.front(); }
-        const auto &back() const { return deque_.back(); }
-        auto &back() { return deque_.back(); }
-        const T &operator[](size_t index) const { return deque_[index]; }
-        T &operator[](size_t index) { return deque_[index]; }
-        std::deque<T> deque_;
+        Sophus::SE3d last_pose;
+        Sophus::SE3d before_last_pose;
     };
 
 public:
@@ -97,11 +88,11 @@ public:
 public:
     // Extra C++ API to facilitate ROS debugging
     std::vector<Eigen::Vector3d> LocalMap() const { return local_map_.Pointcloud(); };
-    std::vector<Sophus::SE3d> poses() const { return poses_; };
+    // std::vector<Sophus::SE3d> poses() const { return poses_; };
 
 private:
     // KISS-ICP pipeline modules
-    fixed_size_vector<Sophus::SE3d> poses_;
+    PosesSlidingWindow poses_;
     KISSConfig config_;
     Registration registration_;
     VoxelHashMap local_map_;

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -22,12 +22,10 @@
 #pragma once
 
 #include <Eigen/Core>
-#include <deque>
 #include <sophus/se3.hpp>
 #include <tuple>
 #include <vector>
 
-#include "kiss_icp/core/Deskew.hpp"
 #include "kiss_icp/core/Registration.hpp"
 #include "kiss_icp/core/Threshold.hpp"
 #include "kiss_icp/core/VoxelHashMap.hpp"

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -78,6 +78,7 @@ public:
 public:
     // Extra C++ API to facilitate ROS debugging
     std::vector<Eigen::Vector3d> LocalMap() const { return local_map_.Pointcloud(); };
+    Sophus::SE3d CurrentPose() const { return last_pose_; }
 
 private:
     // KISS-ICP pipeline modules

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -72,8 +72,6 @@ public:
     Vector3dVectorTuple RegisterFrame(const std::vector<Eigen::Vector3d> &frame,
                                       const std::vector<double> &timestamps);
     Vector3dVectorTuple Voxelize(const std::vector<Eigen::Vector3d> &frame) const;
-    double GetAdaptiveThreshold();
-    bool HasMoved();
 
 public:
     // Extra C++ API to facilitate ROS debugging

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -73,8 +73,6 @@ public:
                                       const std::vector<double> &timestamps);
     Vector3dVectorTuple Voxelize(const std::vector<Eigen::Vector3d> &frame) const;
 
-public:
-    // Extra C++ API to facilitate ROS debugging
     std::vector<Eigen::Vector3d> LocalMap() const { return local_map_.Pointcloud(); };
     Sophus::SE3d CurrentPose() const { return last_pose_; }
 

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -73,7 +73,6 @@ public:
                                       const std::vector<double> &timestamps);
     Vector3dVectorTuple Voxelize(const std::vector<Eigen::Vector3d> &frame) const;
     double GetAdaptiveThreshold();
-    Sophus::SE3d GetPredictionModel() const;
     bool HasMoved();
 
 public:
@@ -83,7 +82,7 @@ public:
 private:
     // KISS-ICP pipeline modules
     Sophus::SE3d last_pose_;
-    Sophus::SE3d last_delta_;
+    Sophus::SE3d last_prediction_;
     KISSConfig config_;
     Registration registration_;
     VoxelHashMap local_map_;

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -73,7 +73,7 @@ public:
 
     std::vector<Eigen::Vector3d> LocalMap() const { return local_map_.Pointcloud(); };
     Sophus::SE3d pose() const { return current_pose_; }
-    Sophus::SE3d delta() const { return current_pose_; }
+    Sophus::SE3d delta() const { return current_delta_; }
 
 private:
     Sophus::SE3d current_pose_;

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -72,12 +72,12 @@ public:
     Vector3dVectorTuple Voxelize(const std::vector<Eigen::Vector3d> &frame) const;
 
     std::vector<Eigen::Vector3d> LocalMap() const { return local_map_.Pointcloud(); };
-    Sophus::SE3d pose() const { return current_pose_; }
-    Sophus::SE3d delta() const { return current_delta_; }
+    Sophus::SE3d pose() const { return last_pose_; }
+    Sophus::SE3d delta() const { return last_delta_; }
 
 private:
-    Sophus::SE3d current_pose_;
-    Sophus::SE3d current_delta_;
+    Sophus::SE3d last_pose_;
+    Sophus::SE3d last_delta_;
 
     // KISS-ICP pipeline modules
     KISSConfig config_;

--- a/python/kiss_icp/deskew.py
+++ b/python/kiss_icp/deskew.py
@@ -31,18 +31,15 @@ def get_motion_compensator(config: KISSConfig):
 
 
 class StubCompensator:
-    def deskew_scan(self, frame, poses, timestamps):
+    def deskew_scan(self, frame, timestamps, delta):
         return frame
 
 
 class MotionCompensator:
-    def deskew_scan(self, frame, poses, timestamps):
-        if len(poses) < 2:
-            return frame
+    def deskew_scan(self, frame, timestamps, delta):
         deskew_frame = kiss_icp_pybind._deskew_scan(
             frame=kiss_icp_pybind._Vector3dVector(frame),
             timestamps=timestamps,
-            start_pose=poses[-2],
-            finish_pose=poses[-1],
+            delta=delta,
         )
         return np.asarray(deskew_frame)

--- a/python/kiss_icp/kiss_icp.py
+++ b/python/kiss_icp/kiss_icp.py
@@ -52,7 +52,7 @@ class KissICP:
         source, frame_downsample = self.voxelize(frame)
 
         # Get motion prediction and adaptive_threshold
-        sigma = self.get_adaptive_threshold()
+        sigma = self.adaptive_threshold.get_threshold()
 
         # Compute initial_guess for ICP
         prediction = self.get_prediction_model()
@@ -78,22 +78,7 @@ class KissICP:
         source = voxel_down_sample(frame_downsample, self.config.mapping.voxel_size * 1.5)
         return source, frame_downsample
 
-    def get_adaptive_threshold(self):
-        return (
-            self.config.adaptive_threshold.initial_threshold
-            if not self.has_moved()
-            else self.adaptive_threshold.get_threshold()
-        )
-
     def get_prediction_model(self):
         if len(self.poses) < 2:
             return np.eye(4)
         return np.linalg.inv(self.poses[-2]) @ self.poses[-1]
-
-    def has_moved(self):
-        return True
-        # if len(self.poses) < 1:
-        #     return False
-        # compute_motion = lambda T1, T2: np.linalg.norm((np.linalg.inv(T1) @ T2)[:3, -1])
-        # motion = compute_motion(self.poses[0], self.poses[-1])
-        # return motion > 5 * self.config.adaptive_threshold.min_motion_th

--- a/python/kiss_icp/kiss_icp.py
+++ b/python/kiss_icp/kiss_icp.py
@@ -33,7 +33,6 @@ from kiss_icp.voxelization import voxel_down_sample
 
 class KissICP:
     def __init__(self, config: KISSConfig):
-        self.poses = []
         self.current_pose = np.eye(4)
         self.current_delta = np.eye(4)
         self.config = config
@@ -45,7 +44,7 @@ class KissICP:
 
     def register_frame(self, frame, timestamps):
         # Apply motion compensation
-        frame = self.compensator.deskew_scan(frame, self.poses, timestamps)
+        frame = self.compensator.deskew_scan(frame, timestamps, self.current_delta)
 
         # Preprocess the input cloud
         frame = self.preprocess(frame)
@@ -79,9 +78,6 @@ class KissICP:
         self.local_map.update(frame_downsample, new_pose)
         self.current_delta = np.linalg.inv(last_pose) @ new_pose
         self.current_pose = new_pose
-
-        # Unique in Pyton pipeline, update trajectory
-        self.poses.append(new_pose)
 
         # Return the (deskew) input raw scan (frame) and the points used for registration (source)
         return frame, source

--- a/python/kiss_icp/kiss_icp.py
+++ b/python/kiss_icp/kiss_icp.py
@@ -91,8 +91,9 @@ class KissICP:
         return np.linalg.inv(self.poses[-2]) @ self.poses[-1]
 
     def has_moved(self):
-        if len(self.poses) < 1:
-            return False
-        compute_motion = lambda T1, T2: np.linalg.norm((np.linalg.inv(T1) @ T2)[:3, -1])
-        motion = compute_motion(self.poses[0], self.poses[-1])
-        return motion > 5 * self.config.adaptive_threshold.min_motion_th
+        return True
+        # if len(self.poses) < 1:
+        #     return False
+        # compute_motion = lambda T1, T2: np.linalg.norm((np.linalg.inv(T1) @ T2)[:3, -1])
+        # motion = compute_motion(self.poses[0], self.poses[-1])
+        # return motion > 5 * self.config.adaptive_threshold.min_motion_th

--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -65,7 +65,7 @@ class OdometryPipeline:
         self.odometry = KissICP(config=self.config)
         self.results = PipelineResults()
         self.times = []
-        self.poses = self.odometry.poses
+        self.poses = []
         self.has_gt = hasattr(self._dataset, "gt_poses")
         self.gt_poses = self._dataset.gt_poses[self._first : self._last] if self.has_gt else None
         self.dataset_name = self._dataset.__class__.__name__
@@ -97,6 +97,7 @@ class OdometryPipeline:
             raw_frame, timestamps = self._next(idx)
             start_time = time.perf_counter_ns()
             source, keypoints = self.odometry.register_frame(raw_frame, timestamps)
+            self.poses.append(self.odometry.current_pose)
             self.times.append(time.perf_counter_ns() - start_time)
             self.visualizer.update(source, keypoints, self.odometry.local_map, self.poses[-1])
 

--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -97,7 +97,7 @@ class OdometryPipeline:
             raw_frame, timestamps = self._next(idx)
             start_time = time.perf_counter_ns()
             source, keypoints = self.odometry.register_frame(raw_frame, timestamps)
-            self.poses.append(self.odometry.current_pose)
+            self.poses.append(self.odometry.last_pose)
             self.times.append(time.perf_counter_ns() - start_time)
             self.visualizer.update(source, keypoints, self.odometry.local_map, self.poses[-1])
 

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -107,14 +107,22 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
 
     // DeSkewScan
     m.def(
-        "_deskew_scan",
-        [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
-           const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish) {
-            Sophus::SE3d start_pose(T_start);
-            Sophus::SE3d finish_pose(T_finish);
-            return DeSkewScan(frame, timestamps, start_pose, finish_pose);
-        },
-        "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a);
+         "_deskew_scan",
+         [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
+            const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish) {
+             Sophus::SE3d start_pose(T_start);
+             Sophus::SE3d finish_pose(T_finish);
+             return DeSkewScan(frame, timestamps, start_pose, finish_pose);
+         },
+         "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a)
+        .def(
+            "_deskew_scan",
+            [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
+               const Eigen::Matrix4d &T_delta) {
+                Sophus::SE3d delta(T_delta);
+                return DeSkewScan(frame, timestamps, delta);
+            },
+            "frame"_a, "timestamps"_a, "delta"_a);
 
     // prerpocessing modules
     m.def("_voxel_down_sample", &VoxelDownsample, "frame"_a, "voxel_size"_a);

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -107,22 +107,13 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
 
     // DeSkewScan
     m.def(
-         "_deskew_scan",
-         [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
-            const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish) {
-             Sophus::SE3d start_pose(T_start);
-             Sophus::SE3d finish_pose(T_finish);
-             return DeSkewScan(frame, timestamps, start_pose, finish_pose);
-         },
-         "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a)
-        .def(
-            "_deskew_scan",
-            [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
-               const Eigen::Matrix4d &T_delta) {
-                Sophus::SE3d delta(T_delta);
-                return DeSkewScan(frame, timestamps, delta);
-            },
-            "frame"_a, "timestamps"_a, "delta"_a);
+        "_deskew_scan",
+        [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
+           const Eigen::Matrix4d &T_delta) {
+            Sophus::SE3d delta(T_delta);
+            return DeSkewScan(frame, timestamps, delta);
+        },
+        "frame"_a, "timestamps"_a, "delta"_a);
 
     // prerpocessing modules
     m.def("_voxel_down_sample", &VoxelDownsample, "frame"_a, "voxel_size"_a);

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -137,7 +137,7 @@ void OdometryServer::RegisterFrame(const sensor_msgs::msg::PointCloud2::ConstSha
     const auto &[frame, keypoints] = kiss_icp_->RegisterFrame(points, timestamps);
 
     // Extract the last KISS-ICP pose, ego-centric to the LiDAR
-    const Sophus::SE3d kiss_pose = kiss_icp_->CurrentPose();
+    const Sophus::SE3d kiss_pose = kiss_icp_->pose();
 
     // Spit the current estimated pose to ROS msgs handling the desired target frame
     PublishOdometry(kiss_pose, msg->header);
@@ -187,7 +187,7 @@ void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> frame,
                                    const std::vector<Eigen::Vector3d> keypoints,
                                    const std_msgs::msg::Header &header) {
     const auto kiss_map = kiss_icp_->LocalMap();
-    const auto kiss_pose = kiss_icp_->CurrentPose().inverse();
+    const auto kiss_pose = kiss_icp_->pose().inverse();
 
     frame_publisher_->publish(std::move(EigenToPointCloud2(frame, header)));
     kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, header)));

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -137,7 +137,7 @@ void OdometryServer::RegisterFrame(const sensor_msgs::msg::PointCloud2::ConstSha
     const auto &[frame, keypoints] = kiss_icp_->RegisterFrame(points, timestamps);
 
     // Extract the last KISS-ICP pose, ego-centric to the LiDAR
-    const Sophus::SE3d kiss_pose = kiss_icp_->poses().back();
+    const Sophus::SE3d kiss_pose = kiss_icp_->CurrentPose();
 
     // Spit the current estimated pose to ROS msgs handling the desired target frame
     PublishOdometry(kiss_pose, msg->header);
@@ -187,7 +187,7 @@ void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> frame,
                                    const std::vector<Eigen::Vector3d> keypoints,
                                    const std_msgs::msg::Header &header) {
     const auto kiss_map = kiss_icp_->LocalMap();
-    const auto kiss_pose = kiss_icp_->poses().back().inverse();
+    const auto kiss_pose = kiss_icp_->CurrentPose().inverse();
 
     frame_publisher_->publish(std::move(EigenToPointCloud2(frame, header)));
     kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, header)));


### PR DESCRIPTION
The idea of this PR is to provide a solution to #122 that also improves the whole KISS-ICP implementation

## General Idea
 I think I'm happy in general with moving away to maintaining an infinite list of poses just to always use the current one (`current_pose_`) and the difference to the last (`current_delta_`). So I think the system is benefiting from this change as we don't add extra stuff just because. It models better the problem we are trying to solve and expresses more clearly what we need to keep track of to solve that problem with our approach

## What we changed
-  Removed the `std::vector<Sophus::SE3d>` poses_ member from the C++ pipeline. 
- Added a `current_pose_` (name to be defined) and `current_delta_` (as this is the only variable we were generating from the `poses_[N-2]`
- Extended the deskew function to account for being called with the `delta` estimation instead of the start/end poses. ~(this was not overloaded in the Python module)~  done in a8c39f6a22d709423d2ce12b15564bb6282197f4
- Simplified the adaptive threshold, and removed a bunch of ugly `HasMoved`, etc utility functions
- Try to merge more conceptually the Python and C++ pipelines
- Added some minor comments into the main loops to improve readability for new users

## Important
The Python pipeline will be now the only system that contains the full trajectory. As the C++ one is mainly consumed in ROS it's trivial to create a trajectory by just subscribing to the `kiss/odometry` topic in general

Update: a8c39f6a22d709423d2ce12b15564bb6282197f4 shows how this trajectory should be handled in the "application" and not in the KISS ICP mehotd itself, making the kiss_icp.py even more similar to the C++ evil twin

## To do

- [x] Tests this in a bunch of datasets
- [x] Analyze the there is a real impact with the new approach for the adaptive threshold (97% sure that there is no real change)
- [x] Define what to do with the Deskew API (1 function with just the delta as input, 2 functions, pybinds)
- [x] **DEFINE NEW NAMES**. `delta` Is a bit generic, `current_pose` is the current, the last, which pose? I put `pose` since the moment you ask Kiss for this data member will give you the current estimate it has. Should `delta` be renamed to `prediction` ? I dunno