### PR TITLE
Reduce compute in RemovePointsFarFromLocation

### DIFF
--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -85,10 +85,10 @@ void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
 }
 
 void VoxelHashMap::RemovePointsFarFromLocation(const Eigen::Vector3d &origin) {
+    const auto max_distance2 = max_distance_ * max_distance_;
     for (auto it = map_.begin(); it != map_.end();) {
         const auto &[voxel, voxel_block] = *it;
         const auto &pt = voxel_block.points.front();
-        const auto max_distance2 = max_distance_ * max_distance_;
         if ((pt - origin).squaredNorm() >= (max_distance2)) {
             it = map_.erase(it);
         } else {


### PR DESCRIPTION
Remove unnecessary computation in each loop of the VoxelHashMap RemovePointsFarFromLocation function

In some situations the compiler may do this optimization, but I figured this is a pretty low risk change