### PR TITLE
Get absolute path first in case . is data_dir

### DIFF
--- a/python/kiss_icp/datasets/generic.py
+++ b/python/kiss_icp/datasets/generic.py
@@ -33,7 +33,7 @@ from kiss_icp.datasets import supported_file_extensions
 class GenericDataset:
     def __init__(self, data_dir: Path, *_, **__):
         # Config stuff
-        self.sequence_id = os.path.basename(data_dir)
+        self.sequence_id = os.path.basename(os.path.abspath(data_dir))
         self.scans_dir = os.path.join(os.path.realpath(data_dir), "")
         self.scan_files = np.array(
             natsort.natsorted(


### PR DESCRIPTION
@louis-wiesmann caught a small bug when running the `kiss_icp_pipeline` directly in the data folder. The generic data loader will use the "." as the sequence_dir, and the poses will be saved to `._poses.txt` and will therefore be hidden :laughing: 

This should fix it.