### PR TITLE
helipr - add to sequence dataloader, remove file extension check

### DIFF
--- a/python/kiss_icp/datasets/__init__.py
+++ b/python/kiss_icp/datasets/__init__.py
@@ -39,7 +39,7 @@ def supported_file_extensions():
 
 def sequence_dataloaders():
     # TODO: automatically infer this
-    return ["kitti", "kitti_raw", "nuscenes"]
+    return ["kitti", "kitti_raw", "nuscenes", "helipr"]
 
 
 def available_dataloaders() -> List:

--- a/python/kiss_icp/datasets/helipr.py
+++ b/python/kiss_icp/datasets/helipr.py
@@ -68,9 +68,6 @@ class HeLiPRDataset:
         )
         if len(self.scan_files) == 0:
             raise ValueError(f"Tried to read point cloud files in {data_dir} but none found")
-        self.file_extension = self.scan_files[0].split(".")[-1]
-        if self.file_extension not in supported_file_extensions():
-            raise ValueError(f"Supported formats are: {supported_file_extensions()}")
 
         # Obtain the pointcloud reader for the given data folder
         if self.sequence_id == "Avia":


### PR DESCRIPTION
1. Add helipr to list of sequence dataloaders
2. Remove file extension check for point clouds, HeliPR gives .bin format by default