### PR TITLE
Consistent type for GT poses

### DIFF
--- a/python/kiss_icp/datasets/helipr.py
+++ b/python/kiss_icp/datasets/helipr.py
@@ -53,9 +53,10 @@ class HeLiPRDataset:
         pose_timestamps, poses = self.read_poses(pose_file)
 
         # Match number of scans with number of references poses available
-        self.gt_poses = [
-            pose for time, pose in zip(pose_timestamps, poses) if time in scan_timestamps
-        ]
+        self.gt_poses = np.array(
+            [pose for time, pose in zip(pose_timestamps, poses) if time in scan_timestamps]
+        ).reshape(-1, 4, 4)
+
         scan_files = [file for file in scan_files if int(Path(file).stem) in pose_timestamps]
 
         self.scan_files = np.array(

--- a/python/kiss_icp/datasets/paris_luco.py
+++ b/python/kiss_icp/datasets/paris_luco.py
@@ -59,7 +59,7 @@ class ParisLucoDataset:
             T = np.eye(4)
             T[:3, 3] = xyz
             gt_poses.append(T)
-        return gt_poses
+        return np.array(gt_poses).reshape(-1, 4, 4)
 
     def apply_calibration(self, poses):
         """ParisLucoDataset only has a x, y, z trajectory, so we must will em all"""

--- a/python/kiss_icp/metrics.py
+++ b/python/kiss_icp/metrics.py
@@ -27,9 +27,7 @@ import numpy as np
 from kiss_icp.pybind import kiss_icp_pybind
 
 
-def sequence_error(
-    gt_poses: np.ndarray, results_poses: List[np.ndarray]
-) -> Tuple[float, float]:
+def sequence_error(gt_poses: np.ndarray, results_poses: List[np.ndarray]) -> Tuple[float, float]:
     """Sptis the sequence error for a given trajectory in camera coordinate frames."""
     return kiss_icp_pybind._kitti_seq_error(gt_poses, results_poses)
 

--- a/python/kiss_icp/metrics.py
+++ b/python/kiss_icp/metrics.py
@@ -28,14 +28,14 @@ from kiss_icp.pybind import kiss_icp_pybind
 
 
 def sequence_error(
-    gt_poses: List[np.ndarray], results_poses: List[np.ndarray]
+    gt_poses: np.ndarray, results_poses: List[np.ndarray]
 ) -> Tuple[float, float]:
     """Sptis the sequence error for a given trajectory in camera coordinate frames."""
     return kiss_icp_pybind._kitti_seq_error(gt_poses, results_poses)
 
 
 def absolute_trajectory_error(
-    gt_poses: List[np.ndarray], results_poses: List[np.ndarray]
+    gt_poses: np.ndarray, results_poses: List[np.ndarray]
 ) -> Tuple[float, float]:
     """Sptis the sequence error for a given trajectory in camera coordinate frames."""
     return kiss_icp_pybind._absolute_trajectory_error(gt_poses, results_poses)


### PR DESCRIPTION
This is a minor thing, but the type annotation for the GT poses was a list of `np.array`. However, we usually return a single `np.array`.

I changed the type annotation and made the return type consistent for the Python dataloaders.