### PR TITLE
EXCLUDE_FROM_ALL goes into the FetchContent_Declare

### DIFF
--- a/cpp/kiss_icp/3rdparty/eigen/eigen.cmake
+++ b/cpp/kiss_icp/3rdparty/eigen/eigen.cmake
@@ -32,16 +32,6 @@ set(EIGEN_BUILD_BLAS OFF CACHE BOOL "Don't build blas module")
 set(EIGEN_BUILD_LAPACK OFF CACHE BOOL "Don't build lapack module")
 
 include(FetchContent)
-FetchContent_Declare(eigen URL https://github.com/nachovizzo/eigen/archive/refs/tags/3.4.90.tar.gz)
-if(NOT eigen_POPULATED)
-  FetchContent_Populate(eigen)
-  if(${CMAKE_VERSION} GREATER_EQUAL 3.25)
-    add_subdirectory(${eigen_SOURCE_DIR} ${eigen_BINARY_DIR} SYSTEM EXCLUDE_FROM_ALL)
-  else()
-    # Emulate the SYSTEM flag introduced in CMake 3.25. Withouth this flag the compiler will
-    # consider this 3rdparty headers as source code and fail due the -Werror flag.
-    add_subdirectory(${eigen_SOURCE_DIR} ${eigen_BINARY_DIR} EXCLUDE_FROM_ALL)
-    get_target_property(eigen_include_dirs eigen INTERFACE_INCLUDE_DIRECTORIES)
-    set_target_properties(eigen PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${eigen_include_dirs}")
-  endif()
-endif()
+FetchContent_Declare(eigen URL https://github.com/nachovizzo/eigen/archive/refs/tags/3.4.90.tar.gz EXCLUDE_FROM_ALL
+                               TRUE)
+FetchContent_MakeAvailable(eigen)

--- a/cpp/kiss_icp/3rdparty/tbb/tbb.cmake
+++ b/cpp/kiss_icp/3rdparty/tbb/tbb.cmake
@@ -28,16 +28,6 @@ option(TBB_STRICT OFF)
 option(TBB_TEST OFF)
 
 include(FetchContent)
-FetchContent_Declare(tbb URL https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.8.0.tar.gz)
-if(NOT tbb_POPULATED)
-  FetchContent_Populate(tbb)
-  if(${CMAKE_VERSION} GREATER_EQUAL 3.25)
-    add_subdirectory(${tbb_SOURCE_DIR} ${tbb_BINARY_DIR} SYSTEM EXCLUDE_FROM_ALL)
-  else()
-    # Emulate the SYSTEM flag introduced in CMake 3.25. Withouth this flag the compiler will
-    # consider this 3rdparty headers as source code and fail due the -Werror flag.
-    add_subdirectory(${tbb_SOURCE_DIR} ${tbb_BINARY_DIR} EXCLUDE_FROM_ALL)
-    get_target_property(tbb_include_dirs tbb INTERFACE_INCLUDE_DIRECTORIES)
-    set_target_properties(tbb PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${tbb_include_dirs}")
-  endif()
-endif()
+FetchContent_Declare(tbb URL https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.8.0.tar.gz EXCLUDE_FROM_ALL
+                             TRUE)
+FetchContent_MakeAvailable(tbb)


### PR DESCRIPTION
This fixes the `FetchContent` population error that we introduced many months before. We were checking for a `depname_Populated` without using `FetchContent_GetProperties(depname)'. This resulted in cmake error as it was trying to populate the same dependency multiple times if KISS was "_fetch contented_" by another cmake project that was also "_fetch conteting_" one of the KISS dependencies. 