### PR TITLE
Adjust Global Frame in odometry pipeline

### DIFF
--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -81,7 +81,7 @@ KissICP::Vector3dVectorTuple KissICP::Voxelize(const std::vector<Eigen::Vector3d
     const auto source = kiss_icp::VoxelDownsample(frame_downsample, voxel_size * 1.5);
     return {source, frame_downsample};
 }
-void KissICP::resetGlobalFrame(const Sophus::SE3d &global_frame_correction) {
+void KissICP::adjustGlobalFrame(const Sophus::SE3d &global_frame_correction) {
     last_pose_ = global_frame_correction * last_pose_;
     KissICP::Vector3dVector map_points = local_map_.Pointcloud();
     local_map_.Clear();

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -81,4 +81,5 @@ KissICP::Vector3dVectorTuple KissICP::Voxelize(const std::vector<Eigen::Vector3d
     const auto source = kiss_icp::VoxelDownsample(frame_downsample, voxel_size * 1.5);
     return {source, frame_downsample};
 }
+
 }  // namespace kiss_icp::pipeline

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -81,5 +81,13 @@ KissICP::Vector3dVectorTuple KissICP::Voxelize(const std::vector<Eigen::Vector3d
     const auto source = kiss_icp::VoxelDownsample(frame_downsample, voxel_size * 1.5);
     return {source, frame_downsample};
 }
+void KissICP::resetGlobalFrame(const Sophus::SE3d &global_frame_correction) {
+    last_pose_ = global_frame_correction * last_pose_;
+    KissICP::Vector3dVector map_points = local_map_.Pointcloud();
+    local_map_.Clear();
+    std::transform(map_points.cbegin(), map_points.cend(), map_points.begin(),
+                   [&](const auto &p) { return global_frame_correction * p; });
+    local_map_.AddPoints(map_points);
+}
 
 }  // namespace kiss_icp::pipeline

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -81,13 +81,4 @@ KissICP::Vector3dVectorTuple KissICP::Voxelize(const std::vector<Eigen::Vector3d
     const auto source = kiss_icp::VoxelDownsample(frame_downsample, voxel_size * 1.5);
     return {source, frame_downsample};
 }
-void KissICP::adjustGlobalFrame(const Sophus::SE3d &global_frame_correction) {
-    last_pose_ = global_frame_correction * last_pose_;
-    KissICP::Vector3dVector map_points = local_map_.Pointcloud();
-    local_map_.Clear();
-    std::transform(map_points.cbegin(), map_points.cend(), map_points.begin(),
-                   [&](const auto &p) { return global_frame_correction * p; });
-    local_map_.AddPoints(map_points);
-}
-
 }  // namespace kiss_icp::pipeline

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -72,10 +72,15 @@ public:
     Vector3dVectorTuple Voxelize(const std::vector<Eigen::Vector3d> &frame) const;
 
     std::vector<Eigen::Vector3d> LocalMap() const { return local_map_.Pointcloud(); };
-    Sophus::SE3d pose() const { return last_pose_; }
-    Sophus::SE3d delta() const { return last_delta_; }
 
-    void adjustGlobalFrame(const Sophus::SE3d &global_frame_correction);
+    const VoxelHashMap &VoxelMap() const { return local_map_; };
+    VoxelHashMap &VoxelMap() { return local_map_; };
+
+    const Sophus::SE3d &pose() const { return last_pose_; }
+    Sophus::SE3d &pose() { return last_pose_; }
+
+    const Sophus::SE3d &delta() const { return last_delta_; }
+    Sophus::SE3d &delta() { return last_delta_; }
 
 private:
     Sophus::SE3d last_pose_;

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -75,6 +75,8 @@ public:
     Sophus::SE3d pose() const { return last_pose_; }
     Sophus::SE3d delta() const { return last_delta_; }
 
+    void resetGlobalFrame(const Sophus::SE3d &global_frame_correction);
+
 private:
     Sophus::SE3d last_pose_;
     Sophus::SE3d last_delta_;

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -75,7 +75,7 @@ public:
     Sophus::SE3d pose() const { return last_pose_; }
     Sophus::SE3d delta() const { return last_delta_; }
 
-    void resetGlobalFrame(const Sophus::SE3d &global_frame_correction);
+    void adjustGlobalFrame(const Sophus::SE3d &global_frame_correction);
 
 private:
     Sophus::SE3d last_pose_;


### PR DESCRIPTION
Me and @benemer added this change so that it is possible to adjust the global reference frame of KISS. This can be useful if one needs to adjust the pose estimate based on a new global pose measurement (coming from GPS, April tag localization system, or any indoor global localization system out there). Notice that this change only affects the CPP API, as a user can already do this manually in Python. For the ROS "API", this highly depends on the global measurement used, which we can probably also leave to the users in their custom nodes.

