### PR TITLE
Add empty pipeline constructor

### DIFF
--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -168,12 +168,12 @@ LinearSystem BuildLinearSystem(const Correspondences &correspondences, const dou
 namespace kiss_icp {
 
 // Need to provide a definition to the static attribute
-tbb::global_control Registration::tbb_control_settings(
-    tbb::global_control::max_allowed_parallelism,
-    static_cast<size_t>(tbb::info::default_concurrency()));
 
 Registration::Registration(int max_num_iteration, double convergence_criterion, int max_num_threads)
-    : max_num_iterations_(max_num_iteration), convergence_criterion_(convergence_criterion) {
+    : max_num_iterations_(max_num_iteration),
+      convergence_criterion_(convergence_criterion),
+      tbb_control_settings(tbb::global_control::max_allowed_parallelism,
+                           static_cast<size_t>(tbb::info::default_concurrency())) {
     // Only manipulate the number of threads if the user specifies something greater than 0
     if (max_num_threads > 0) {
         tbb_control_settings = tbb::global_control(tbb::global_control::max_allowed_parallelism,

--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -168,14 +168,11 @@ LinearSystem BuildLinearSystem(const Correspondences &correspondences, const dou
 namespace kiss_icp {
 
 Registration::Registration(int max_num_iteration, double convergence_criterion, int max_num_threads)
-    : max_num_iterations_(max_num_iteration),
-      convergence_criterion_(convergence_criterion),
-      // Only manipulate the number of threads if the user specifies something greater than 0
-      max_num_threads_(max_num_threads > 0 ? max_num_threads : tbb::info::default_concurrency()) {
-    // This global variable requires static duration storage to be able to manipulate the max
-    // concurrency from TBB across the entire class
-    static const auto tbb_control_settings = tbb::global_control(
-        tbb::global_control::max_allowed_parallelism, static_cast<size_t>(max_num_threads_));
+    : max_num_iterations_(max_num_iteration), convergence_criterion_(convergence_criterion) {
+    // Only manipulate the number of threads if the user specifies something greater than 0
+    auto max_threads = max_num_threads > 0 ? max_num_threads : tbb::info::default_concurrency();
+    tbb_control_settings = tbb::global_control(tbb::global_control::max_allowed_parallelism,
+                                               static_cast<size_t>(max_threads));
 }
 
 Sophus::SE3d Registration::AlignPointsToMap(const std::vector<Eigen::Vector3d> &frame,

--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -167,12 +167,18 @@ LinearSystem BuildLinearSystem(const Correspondences &correspondences, const dou
 
 namespace kiss_icp {
 
+// Need to provide a definition to the static attribute
+tbb::global_control Registration::tbb_control_settings(
+    tbb::global_control::max_allowed_parallelism,
+    static_cast<size_t>(tbb::info::default_concurrency()));
+
 Registration::Registration(int max_num_iteration, double convergence_criterion, int max_num_threads)
     : max_num_iterations_(max_num_iteration), convergence_criterion_(convergence_criterion) {
     // Only manipulate the number of threads if the user specifies something greater than 0
-    auto max_threads = max_num_threads > 0 ? max_num_threads : tbb::info::default_concurrency();
-    tbb_control_settings = tbb::global_control(tbb::global_control::max_allowed_parallelism,
-                                               static_cast<size_t>(max_threads));
+    if (max_num_threads > 0) {
+        tbb_control_settings = tbb::global_control(tbb::global_control::max_allowed_parallelism,
+                                                   static_cast<size_t>(max_num_threads));
+    }
 }
 
 Sophus::SE3d Registration::AlignPointsToMap(const std::vector<Eigen::Vector3d> &frame,

--- a/cpp/kiss_icp/core/Registration.hpp
+++ b/cpp/kiss_icp/core/Registration.hpp
@@ -22,6 +22,8 @@
 // SOFTWARE.
 #pragma once
 
+#include <oneapi/tbb/global_control.h>
+
 #include <Eigen/Core>
 #include <sophus/se3.hpp>
 #include <vector>
@@ -41,6 +43,8 @@ struct Registration {
 
     int max_num_iterations_;
     double convergence_criterion_;
-    int max_num_threads_;
+    // This attribute requires static to be able to manipulate the max
+    // concurrency from TBB across multiple instances of this class
+    static tbb::global_control tbb_control_settings;
 };
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Registration.hpp
+++ b/cpp/kiss_icp/core/Registration.hpp
@@ -22,7 +22,8 @@
 // SOFTWARE.
 #pragma once
 
-#include <oneapi/tbb/global_control.h>
+#include <tbb/global_control.h>
+#include <tbb/info.h>
 
 #include <Eigen/Core>
 #include <sophus/se3.hpp>

--- a/cpp/kiss_icp/core/Registration.hpp
+++ b/cpp/kiss_icp/core/Registration.hpp
@@ -44,8 +44,8 @@ struct Registration {
 
     int max_num_iterations_;
     double convergence_criterion_;
-    // This attribute requires static to be able to manipulate the max
-    // concurrency from TBB across multiple instances of this class
-    static tbb::global_control tbb_control_settings;
+    // This attribute is needed to be able to manipulate the max
+    // concurrency from TBB this class
+    tbb::global_control tbb_control_settings;
 };
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -58,6 +58,7 @@ public:
     using Vector3dVectorTuple = std::tuple<Vector3dVector, Vector3dVector>;
 
 public:
+    explicit KissICP() : KissICP(KISSConfig()) {}
     explicit KissICP(const KISSConfig &config)
         : config_(config),
           registration_(
@@ -74,6 +75,7 @@ public:
     std::vector<Eigen::Vector3d> LocalMap() const { return local_map_.Pointcloud(); };
     Sophus::SE3d pose() const { return last_pose_; }
     Sophus::SE3d delta() const { return last_delta_; }
+    const KISSConfig &config() const { return config_; }
 
 private:
     Sophus::SE3d last_pose_;

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -89,10 +89,7 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
                     .matrix();
             },
             "points"_a, "voxel_map"_a, "initial_guess"_a, "max_correspondance_distance"_a,
-            "kernel"_a)
-        .def_property_readonly_static("tbb_control_settings", [](py::object self) {
-            return Registration::tbb_control_settings;
-        });
+            "kernel"_a);
 
     // AdaptiveThreshold bindings
     py::class_<AdaptiveThreshold> adaptive_threshold(m, "_AdaptiveThreshold", "Don't use this");

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -89,7 +89,10 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
                     .matrix();
             },
             "points"_a, "voxel_map"_a, "initial_guess"_a, "max_correspondance_distance"_a,
-            "kernel"_a);
+            "kernel"_a)
+        .def_property_readonly_static("tbb_control_settings", [](py::object self) {
+            return Registration::tbb_control_settings;
+        });
 
     // AdaptiveThreshold bindings
     py::class_<AdaptiveThreshold> adaptive_threshold(m, "_AdaptiveThreshold", "Don't use this");

--- a/ros/src/OdometryServer.hpp
+++ b/ros/src/OdometryServer.hpp
@@ -74,7 +74,7 @@ private:
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr map_publisher_;
 
     /// KISS-ICP
-    std::unique_ptr<kiss_icp::pipeline::KissICP> kiss_icp_;
+    std::unique_ptr<kiss_icp::pipeline::KissICP> kiss_icp_ = nullptr;
 
     /// Global/map coordinate frame.
     std::string odom_frame_{"odom"};


### PR DESCRIPTION
This PR allows you to initialize the pipeline without a config at hand by using the default KISSConfig. In that case, you still want to access the internal config, so we also added an accessor to it.