### PR TITLE
HeLiPR: Make sure chunk size is sufficient

### DIFF
--- a/python/kiss_icp/datasets/helipr.py
+++ b/python/kiss_icp/datasets/helipr.py
@@ -130,7 +130,7 @@ class HeLiPRDataset:
         with open(file_path, "rb") as f:
             binary = f.read()
             offset = 0
-            while offset < len(binary):
+            while offset < len(binary) - chunk_size:
                 list_lines.append(struct.unpack_from(f"={format_string}", binary, offset))
                 offset += chunk_size
         data = np.stack(list_lines)


### PR DESCRIPTION
When reading HeLiPR data, in some sequences (for example `Roundabout02`) the last chunk of data is incomplete and Kiss fails with

```shell
error: unpack_from requires a buffer of at least 999400 bytes for unpacking 25 bytes at offset 999375 (actual buffer size is 999383)
```

This PR fixes this by ensuring we have enough data to read in the last chunk.