### PR TITLE
Changed hash function in preprocessing to be consistent with voxel map hash

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -36,7 +36,7 @@ using Voxel = Eigen::Vector3i;
 struct VoxelHash {
     size_t operator()(const Voxel &voxel) const {
         const uint32_t *vec = reinterpret_cast<const uint32_t *>(voxel.data());
-        return ((1 << 20) - 1) & (vec[0] * 73856093 ^ vec[1] * 19349663 ^ vec[2] * 83492791);
+        return ((1 << 20) - 1) & (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
     }
 };
 }  // namespace


### PR DESCRIPTION
**Hello, I would like to pinpoint small "bug". Hash function in preprocessing isn't consistent with voxel map hash.**

---

This shouldn't change behavior of pipeline but could potentionally improve the speed a little. Hash function should have been made of prime numbers, where 19349663 isn't prime. This PR should fix it.
Thanks for your hard work and your willingness to improve this open source project every day 👌.