### PR TITLE
Handled Zero Division Error in pipeline.py

### DIFF
--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -179,12 +179,21 @@ class OdometryPipeline:
         # Run timing metrics evaluation, always
         def _get_fps():
             total_time_s = sum(self.times) * 1e-9
-            return float(len(self.times) / total_time_s)
+            if total_time_s == 0:
+                return 0  
+            else:
+                return float(len(self.times) / total_time_s)
 
-        avg_fps = int(np.ceil(_get_fps()))
-        avg_ms = int(np.ceil(1e3 * (1 / _get_fps())))
+        fps = _get_fps()
+        if fps == 0:
+            avg_fps = 0
+            avg_ms = 0
+        else:
+            avg_fps = int(np.ceil(fps))
+            avg_ms = int(np.ceil(1e3 / fps))
         self.results.append(desc="Average Frequency", units="Hz", value=avg_fps, trunc=True)
         self.results.append(desc="Average Runtime", units="ms", value=avg_ms, trunc=True)
+
 
     def _write_log(self):
         if not self.results.empty():

--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -179,18 +179,11 @@ class OdometryPipeline:
         # Run timing metrics evaluation, always
         def _get_fps():
             total_time_s = sum(self.times) * 1e-9
-            if total_time_s == 0:
-                return 0  
-            else:
-                return float(len(self.times) / total_time_s)
+            return float(len(self.times) / total_time_s) if total_time_s > 0 else 0
 
         fps = _get_fps()
-        if fps == 0:
-            avg_fps = 0
-            avg_ms = 0
-        else:
-            avg_fps = int(np.ceil(fps))
-            avg_ms = int(np.ceil(1e3 / fps))
+        avg_fps = int(np.floor(fps))
+        avg_ms = int(np.ceil(1e3 / fps)) if fps > 0 else 0
         self.results.append(desc="Average Frequency", units="Hz", value=avg_fps, trunc=True)
         self.results.append(desc="Average Runtime", units="ms", value=avg_ms, trunc=True)
 

--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -181,14 +181,12 @@ class OdometryPipeline:
             total_time_s = sum(self.times) * 1e-9
             return float(len(self.times) / total_time_s) if total_time_s > 0 else 0
 
-        
         fps = _get_fps()
         avg_fps = int(np.floor(fps))
         avg_ms = int(np.ceil(1e3 / fps)) if fps > 0 else 0
         if avg_fps > 0:
             self.results.append(desc="Average Frequency", units="Hz", value=avg_fps, trunc=True)
             self.results.append(desc="Average Runtime", units="ms", value=avg_ms, trunc=True)
-
 
     def _write_log(self):
         if not self.results.empty():

--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -181,11 +181,13 @@ class OdometryPipeline:
             total_time_s = sum(self.times) * 1e-9
             return float(len(self.times) / total_time_s) if total_time_s > 0 else 0
 
+        
         fps = _get_fps()
         avg_fps = int(np.floor(fps))
         avg_ms = int(np.ceil(1e3 / fps)) if fps > 0 else 0
-        self.results.append(desc="Average Frequency", units="Hz", value=avg_fps, trunc=True)
-        self.results.append(desc="Average Runtime", units="ms", value=avg_ms, trunc=True)
+        if avg_fps > 0:
+            self.results.append(desc="Average Frequency", units="Hz", value=avg_fps, trunc=True)
+            self.results.append(desc="Average Runtime", units="ms", value=avg_ms, trunc=True)
 
 
     def _write_log(self):


### PR DESCRIPTION
This pull request addresses a  division by zero error in the `_get_fps()` function. I've implemented a check to handle the case where `total_time_s` is zero to prevent the error. Additionally, I've modified the calculation of `avg_ms` to ensure it doesn't result in a division by zero. 

Changes Made:
- Added a conditional check in `_get_fps()` to handle division by zero.
- Adjusted the calculation of `avg_ms` to prevent division by zero.

Fixes: #343