### PR TITLE
Fix kiss_icp_dump_config executable

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -63,7 +63,7 @@ visualizer = [
 
 [project.scripts]
 kiss_icp_pipeline = "kiss_icp.tools.cmd:run"
-kiss_icp_dump_config = "kiss_icp.config.parser:write_dump_config"
+kiss_icp_dump_config = "kiss_icp.config.parser:write_config"
 
 [project.urls]
 Homepage = "https://github.com/PRBonn/kiss-icp"


### PR DESCRIPTION
The function called with the `kiss_icp_dump_config` executable does not exist, I changed it to the correct `write_config` function.