### PR TITLE
Some memory saving is possible when getting points from voxel hash map

### DIFF
--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -24,7 +24,6 @@
 
 #include <Eigen/Core>
 #include <algorithm>
-#include <limits>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -42,18 +41,21 @@ std::vector<Eigen::Vector3d> VoxelHashMap::GetPoints(const std::vector<Voxel> &q
             }
         }
     });
+    points.shrink_to_fit();
     return points;
 }
 
 std::vector<Eigen::Vector3d> VoxelHashMap::Pointcloud() const {
     std::vector<Eigen::Vector3d> points;
-    points.reserve(max_points_per_voxel_ * map_.size());
-    for (const auto &[voxel, voxel_block] : map_) {
+    points.reserve(map_.size() * static_cast<size_t>(max_points_per_voxel_));
+    std::for_each(map_.cbegin(), map_.cend(), [&](const auto &map_element) {
+        const auto &[voxel, voxel_block] = map_element;
         (void)voxel;
         for (const auto &point : voxel_block.points) {
-            points.push_back(point);
+            points.emplace_back(point);
         }
-    }
+    });
+    points.shrink_to_fit();
     return points;
 }
 


### PR DESCRIPTION
In these two methods of VoxelHasMap the memory for vectors "points" is reserved but never cleared if not completely filled. I checked and size and capacity often doesn't match, resulting in some small waste of memory.
Also, in the method PointCloud() std::for_each is probably better and emplace_back instead of push_back, just to be pedantic. The static cast for max_points_per_voxel_ from int to size_t is there just to be consistent with the method GetPoints().