### PR TITLE
gcc 14 fails compilation - initialize an uninitialized variable

### DIFF
--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -76,7 +76,7 @@ std::tuple<Eigen::Vector3d, double> GetClosestNeighbor(const Eigen::Vector3d &po
     const auto &neighbors = voxel_map.GetPoints(query_voxels);
 
     // Find the nearest neighbor
-    Eigen::Vector3d closest_neighbor;
+    Eigen::Vector3d closest_neighbor = Eigen::Vector3d::Zero();
     double closest_distance = std::numeric_limits<double>::max();
     std::for_each(neighbors.cbegin(), neighbors.cend(), [&](const auto &neighbor) {
         double distance = (neighbor - point).norm();


### PR DESCRIPTION
Compilation with g++-14 (tested on version 14.1.1 20240522) fails because of an uninitialized variable: closest_neighbor in registration.cpp. I just initialize it to 0, since it shouldn't matter anyways.

![image](https://github.com/PRBonn/kiss-icp/assets/93738661/17e5373a-8901-45c0-aa3b-84d753befc2c)
