### PR TITLE
mcap reader: Use extracted topic

### DIFF
--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -46,7 +46,7 @@ class McapDataloader:
         self.summary = self.bag.get_summary()
         self.topic = self.check_topic(topic)
         self.n_scans = self._get_n_scans()
-        self.msgs = read_ros2_messages(mcap_file, topics=topic)
+        self.msgs = read_ros2_messages(mcap_file, topics=self.topic)
         self.read_point_cloud = read_point_cloud
         self.use_global_visualizer = True
 


### PR DESCRIPTION
If no topic is provided, the `self.check_topic` is supposed to extract it, for example, if there is only one message of type `PointCloud2`. However, we did not pass the inferred topic. This is the fix.