### PR TITLE
Make voxel computation consistent across all source code

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -48,9 +48,7 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
     tsl::robin_map<Voxel, Eigen::Vector3d, VoxelHash> grid;
     grid.reserve(frame.size());
     for (const auto &point : frame) {
-        const auto voxel = Voxel(static_cast<int>(std::floor(point.x() / voxel_size)),
-                                 static_cast<int>(std::floor(point.y() / voxel_size)),
-                                 static_cast<int>(std::floor(point.z() / voxel_size)));
+        const Voxel voxel = (point / voxel_size).array().floor().cast<int>();
         if (grid.contains(voxel)) continue;
         grid.insert({voxel, point});
     }

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -42,9 +42,9 @@ struct VoxelHash {
 };
 
 Voxel PointToVoxel(const Eigen::Vector3d &point, double voxel_size) {
-    return {static_cast<int>(std::floor(point.x() / voxel_size)),
-            static_cast<int>(std::floor(point.y() / voxel_size)),
-            static_cast<int>(std::floor(point.z() / voxel_size))};
+    return Voxel(static_cast<int>(std::floor(point.x() / voxel_size)),
+                 static_cast<int>(std::floor(point.y() / voxel_size)),
+                 static_cast<int>(std::floor(point.z() / voxel_size)));
 }
 }  // namespace
 

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -28,7 +28,6 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <cmath>
-#include <numeric>
 #include <sophus/se3.hpp>
 #include <vector>
 

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 namespace {
+// TODO(all): Maybe try to merge these voxel uitls with VoxelHashMap implementation
 using Voxel = Eigen::Vector3i;
 struct VoxelHash {
     size_t operator()(const Voxel &voxel) const {
@@ -39,6 +40,12 @@ struct VoxelHash {
         return ((1 << 20) - 1) & (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
     }
 };
+
+Voxel PointToVoxel(const Eigen::Vector3d &point, double voxel_size) {
+    return {static_cast<int>(std::floor(point.x() / voxel_size)),
+            static_cast<int>(std::floor(point.y() / voxel_size)),
+            static_cast<int>(std::floor(point.z() / voxel_size))};
+}
 }  // namespace
 
 namespace kiss_icp {
@@ -47,7 +54,7 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
     tsl::robin_map<Voxel, Eigen::Vector3d, VoxelHash> grid;
     grid.reserve(frame.size());
     for (const auto &point : frame) {
-        const Voxel voxel = (point / voxel_size).array().floor().cast<int>();
+        const auto voxel = PointToVoxel(point, voxel_size);
         if (grid.contains(voxel)) continue;
         grid.insert({voxel, point});
     }

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -28,6 +28,7 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <cmath>
+#include <numeric>
 #include <sophus/se3.hpp>
 #include <vector>
 
@@ -47,7 +48,9 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
     tsl::robin_map<Voxel, Eigen::Vector3d, VoxelHash> grid;
     grid.reserve(frame.size());
     for (const auto &point : frame) {
-        const auto voxel = Voxel((point / voxel_size).cast<int>());
+        const auto voxel = Voxel(static_cast<int>(std::floor(point.x() / voxel_size)),
+                                 static_cast<int>(std::floor(point.y() / voxel_size)),
+                                 static_cast<int>(std::floor(point.z() / voxel_size)));
         if (grid.contains(voxel)) continue;
         grid.insert({voxel, point});
     }

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -24,7 +24,6 @@
 
 #include <Eigen/Core>
 #include <algorithm>
-#include <numeric>
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -76,9 +76,7 @@ void VoxelHashMap::Update(const std::vector<Eigen::Vector3d> &points, const Soph
 
 void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
     std::for_each(points.cbegin(), points.cend(), [&](const auto &point) {
-        auto voxel = Voxel(static_cast<int>(std::floor(point.x() / voxel_size_)),
-                           static_cast<int>(std::floor(point.y() / voxel_size_)),
-                           static_cast<int>(std::floor(point.z() / voxel_size_)));
+        auto voxel = PointToVoxel(point);
         auto search = map_.find(voxel);
         if (search != map_.end()) {
             auto &voxel_block = search.value();

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -24,6 +24,7 @@
 
 #include <Eigen/Core>
 #include <algorithm>
+#include <numeric>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -75,7 +76,9 @@ void VoxelHashMap::Update(const std::vector<Eigen::Vector3d> &points, const Soph
 
 void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
     std::for_each(points.cbegin(), points.cend(), [&](const auto &point) {
-        auto voxel = Voxel((point / voxel_size_).template cast<int>());
+        auto voxel = Voxel(static_cast<int>(std::floor(point.x() / voxel_size_)),
+                           static_cast<int>(std::floor(point.y() / voxel_size_)),
+                           static_cast<int>(std::floor(point.z() / voxel_size_)));
         auto search = map_.find(voxel);
         if (search != map_.end()) {
             auto &voxel_block = search.value();

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -29,6 +29,7 @@
 #include <tsl/robin_map.h>
 
 #include <Eigen/Core>
+#include <numeric>
 #include <sophus/se3.hpp>
 #include <vector>
 
@@ -58,9 +59,9 @@ struct VoxelHashMap {
     inline void Clear() { map_.clear(); }
     inline bool Empty() const { return map_.empty(); }
     inline Voxel PointToVoxel(const Eigen::Vector3d &point) const {
-        return Voxel(static_cast<int>(point.x() / voxel_size_),
-                     static_cast<int>(point.y() / voxel_size_),
-                     static_cast<int>(point.z() / voxel_size_));
+        return Voxel(static_cast<int>(std::floor(point.x() / voxel_size_)),
+                     static_cast<int>(std::floor(point.y() / voxel_size_)),
+                     static_cast<int>(std::floor(point.z() / voxel_size_)));
     }
     void Update(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &origin);
     void Update(const std::vector<Eigen::Vector3d> &points, const Sophus::SE3d &pose);

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -29,7 +29,6 @@
 #include <tsl/robin_map.h>
 
 #include <Eigen/Core>
-#include <numeric>
 #include <sophus/se3.hpp>
 #include <vector>
 

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -59,9 +59,7 @@ struct VoxelHashMap {
     inline void Clear() { map_.clear(); }
     inline bool Empty() const { return map_.empty(); }
     inline Voxel PointToVoxel(const Eigen::Vector3d &point) const {
-        return Voxel(static_cast<int>(std::floor(point.x() / voxel_size_)),
-                     static_cast<int>(std::floor(point.y() / voxel_size_)),
-                     static_cast<int>(std::floor(point.z() / voxel_size_)));
+        return (point / voxel_size_).array().floor().cast<int>();
     }
     void Update(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &origin);
     void Update(const std::vector<Eigen::Vector3d> &points, const Sophus::SE3d &pose);

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -58,8 +58,11 @@ struct VoxelHashMap {
     inline void Clear() { map_.clear(); }
     inline bool Empty() const { return map_.empty(); }
     inline Voxel PointToVoxel(const Eigen::Vector3d &point) const {
-        return (point / voxel_size_).array().floor().cast<int>();
+        return Voxel(static_cast<int>(std::floor(point.x() / voxel_size_)),
+                     static_cast<int>(std::floor(point.y() / voxel_size_)),
+                     static_cast<int>(std::floor(point.z() / voxel_size_)));
     }
+
     void Update(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &origin);
     void Update(const std::vector<Eigen::Vector3d> &points, const Sophus::SE3d &pose);
     void AddPoints(const std::vector<Eigen::Vector3d> &points);

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -62,7 +62,6 @@ struct VoxelHashMap {
                      static_cast<int>(std::floor(point.y() / voxel_size_)),
                      static_cast<int>(std::floor(point.z() / voxel_size_)));
     }
-
     void Update(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &origin);
     void Update(const std::vector<Eigen::Vector3d> &points, const Sophus::SE3d &pose);
     void AddPoints(const std::vector<Eigen::Vector3d> &points);


### PR DESCRIPTION
1. Make all the source code doing voxel computation use a consistent style of converting and type casting to `Eigen::Vector3i`.
2. Use explicitly the `std::floor` function from `numerics` standard library to have control over the rounding off done while converting `Eigen::Vector3d` to `Eigen::Vector3i`. As mentioned also in #191, it avoids the issue of having large voxels around the origin of each axes.