### PR TITLE
Add timestamps to mcap

### DIFF
--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -46,7 +46,7 @@ class McapDataloader:
         self.summary = self.bag.get_summary()
         self.topic = self.check_topic(topic)
         self.n_scans = self._get_n_scans()
-        self.msgs = read_ros2_messages(mcap_file, topics=self.topic)
+        self.msgs = read_ros2_messages(mcap_file, topics=topic)
         self.timestamps = []
         self.read_point_cloud = read_point_cloud
         self.use_global_visualizer = True

--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -47,6 +47,7 @@ class McapDataloader:
         self.topic = self.check_topic(topic)
         self.n_scans = self._get_n_scans()
         self.msgs = read_ros2_messages(mcap_file, topics=self.topic)
+        self.timestamps = []
         self.read_point_cloud = read_point_cloud
         self.use_global_visualizer = True
 
@@ -56,6 +57,7 @@ class McapDataloader:
 
     def __getitem__(self, idx):
         msg = next(self.msgs).ros_msg
+        self.timestamps.append(self.stamp_to_sec(msg.header.stamp))
         return self.read_point_cloud(msg)
 
     def __len__(self):
@@ -67,6 +69,13 @@ class McapDataloader:
             for (id, count) in self.summary.statistics.channel_message_counts.items()
             if self.summary.channels[id].topic == self.topic
         )
+
+    @staticmethod
+    def stamp_to_sec(stamp):
+        return stamp.sec + float(stamp.nanosec) / 1e9
+
+    def get_frames_timestamps(self) -> list:
+        return self.timestamps
 
     def check_topic(self, topic: str) -> str:
         # Extract schema id from the .mcap file that encodes the PointCloud2 msg

--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -46,7 +46,7 @@ class McapDataloader:
         self.summary = self.bag.get_summary()
         self.topic = self.check_topic(topic)
         self.n_scans = self._get_n_scans()
-        self.msgs = read_ros2_messages(mcap_file, topics=topic)
+        self.msgs = read_ros2_messages(mcap_file, topics=self.topic)
         self.read_point_cloud = read_point_cloud
         self.use_global_visualizer = True
 


### PR DESCRIPTION
To correctly save the poses to the `tum` format, we need the timestamps of the scan. For the `rosbag` reader we extract these from the message header. This PR is implementing the same for the `mcap` reader.

Depends on
https://github.com/PRBonn/kiss-icp/pull/353