### PR TITLE
Attempt to fix macOS CI

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, macos-11]
+        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, macos-14]
     steps:
       - uses: actions/checkout@v3
       - name: Setup cmake

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-11]
+        os: [ubuntu-22.04, windows-2022, macos-14]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, macos-11]
+        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, macos-14]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
 Bumping macos runner to use the latest available for the official github runners to fix the current failing CI due timeouts