### PR TITLE
Initialize hash buckets

### DIFF
--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -53,7 +53,9 @@ struct VoxelHashMap {
     explicit VoxelHashMap(double voxel_size, double max_distance, int max_points_per_voxel)
         : voxel_size_(voxel_size),
           max_distance_(max_distance),
-          max_points_per_voxel_(max_points_per_voxel) {}
+          max_points_per_voxel_(max_points_per_voxel),
+          map_(1 << 20) {}  // <- Number of initial buckets into the robin map, to avoid rehashing
+                            // (a.k.a big copy operation) in the default constructor this is zero.
 
     inline void Clear() { map_.clear(); }
     inline bool Empty() const { return map_.empty(); }


### PR DESCRIPTION
This split  #358 into two parts, this one regards the initial bucket size for the ```robin_map```. 