### PR TITLE
Fix Ubuntu 20.04 dev build

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -39,6 +39,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.apt/cache
+          key: ${{ runner.os }}-apt-${{ hashFiles('**/ubuntu_dependencies.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -25,3 +25,25 @@ jobs:
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/cpp/kiss_icp
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+  # As the previous job will always install the dependencies from cmake, and this is guaranteed to
+  # work, we also want to support dev sandboxes where the main dependencies are already
+  # pre-installed in the system. For now, we only support dev machines under a GNU/Linux
+  # environmnets. If you are reading this and need the same functionallity in Windows/macOS please
+  # open a ticket.
+  cpp_api_dev:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake git libeigen3-dev libtbb-dev
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/cpp/kiss_icp
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/cpp/kiss_icp/core/Deskew.cpp
+++ b/cpp/kiss_icp/core/Deskew.cpp
@@ -39,6 +39,7 @@ std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &fram
                                         const Sophus::SE3d &delta) {
     const auto delta_pose = delta.log();
     std::vector<Eigen::Vector3d> corrected_frame(frame.size());
+    // TODO(All): This tbb execution is ignoring the max_n_threads config value
     tbb::parallel_for(size_t(0), frame.size(), [&](size_t i) {
         const auto motion = Sophus::SE3d::exp((timestamps[i] - mid_pose_timestamp) * delta_pose);
         corrected_frame[i] = motion * frame[i];

--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -26,6 +26,7 @@
 #include <tbb/global_control.h>
 #include <tbb/info.h>
 #include <tbb/parallel_reduce.h>
+#include <tbb/task_arena.h>
 
 #include <algorithm>
 #include <cmath>
@@ -171,7 +172,8 @@ Registration::Registration(int max_num_iteration, double convergence_criterion, 
     : max_num_iterations_(max_num_iteration),
       convergence_criterion_(convergence_criterion),
       // Only manipulate the number of threads if the user specifies something greater than 0
-      max_num_threads_(max_num_threads > 0 ? max_num_threads : tbb::info::default_concurrency()) {
+      max_num_threads_(max_num_threads > 0 ? max_num_threads
+                                           : tbb::this_task_arena::max_concurrency()) {
     // This global variable requires static duration storage to be able to manipulate the max
     // concurrency from TBB across the entire class
     static const auto tbb_control_settings = tbb::global_control(


### PR DESCRIPTION
Fixes https://github.com/PRBonn/kiss-icp/issues/334, which was introduced at https://github.com/PRBonn/kiss-icp/pull/252

# Fix dev machine broken build

So I managed to reproduce the problem reported in #334 in one shot [here](https://github.com/PRBonn/kiss-icp/actions/runs/9859226061/job/27222444506?pr=361)

![image](https://github.com/PRBonn/kiss-icp/assets/21349875/8fa5b776-be36-44ea-9899-698bcc04752f)

FYI: Ubuntu 22.04 is not a problem due to a higher TBB version; proof [here](https://github.com/PRBonn/kiss-icp/actions/runs/9859297922/job/27222692815?pr=361):

## Fix

Changing the way we query the default max concurrency [fixes the dev build](https://github.com/PRBonn/kiss-icp/actions/runs/9859458767/job/27223269217?pr=361)
![image](https://github.com/PRBonn/kiss-icp/assets/21349875/24ded45d-38f3-4758-af08-0d0657d03212)

## Why?

Our glory build system will use the TBB version available and only install from the source if it is not there. Otherwise, the system won't build.

It looks like the default shipped version doesn't have `NUMA_SUPPORT`, and thus, this symbol is not created at compile time, for whatever reason.

![image](https://github.com/PRBonn/kiss-icp/assets/21349875/68c6a422-abac-4c88-bb7d-f6e2ecc34a03)
