### PR TITLE
Revise Voxel functionalities in VoxelHashMap and Preprocessing

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -35,7 +35,7 @@
 
 namespace kiss_icp {
 std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
-                                             double voxel_size) {
+                                             const double voxel_size) {
     tsl::robin_map<Voxel, Eigen::Vector3d> grid;
     grid.reserve(frame.size());
     std::for_each(frame.cbegin(), frame.cend(), [&](const auto &point) {

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -28,25 +28,14 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <cmath>
-#include <kiss_icp/core/VoxelHashMap.hpp>
+#include <kiss_icp/core/VoxelUtils.hpp>
 #include <sophus/se3.hpp>
 #include <vector>
-
-namespace {
-using Voxel = kiss_icp::VoxelHashMap::Voxel;
-using VoxelHash = kiss_icp::VoxelHashMap::VoxelHash;
-
-Voxel PointToVoxel(const Eigen::Vector3d &point, double voxel_size) {
-    return Voxel(static_cast<int>(std::floor(point.x() / voxel_size)),
-                 static_cast<int>(std::floor(point.y() / voxel_size)),
-                 static_cast<int>(std::floor(point.z() / voxel_size)));
-}
-}  // namespace
 
 namespace kiss_icp {
 std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
                                              double voxel_size) {
-    tsl::robin_map<Voxel, Eigen::Vector3d, VoxelHash> grid;
+    tsl::robin_map<Voxel, Eigen::Vector3d> grid;
     grid.reserve(frame.size());
     std::for_each(frame.cbegin(), frame.cend(), [&](const auto &point) {
         const auto voxel = PointToVoxel(point, voxel_size);
@@ -54,7 +43,7 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
     });
     std::vector<Eigen::Vector3d> frame_dowsampled(grid.size());
     std::transform(grid.begin(), grid.end(), frame_dowsampled.begin(),
-                   [](const auto &voxel_and_point) { return voxel_and_point.value(); });
+                   [](const auto &voxel_and_point) { return voxel_and_point.second; });
     return frame_dowsampled;
 }
 

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -28,9 +28,10 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <cmath>
-#include <kiss_icp/core/VoxelUtils.hpp>
 #include <sophus/se3.hpp>
 #include <vector>
+
+#include "VoxelUtils.hpp"
 
 namespace kiss_icp {
 std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -43,9 +43,11 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
         const auto voxel = PointToVoxel(point, voxel_size);
         if (!grid.contains(voxel)) grid.insert({voxel, point});
     });
-    std::vector<Eigen::Vector3d> frame_dowsampled(grid.size());
-    std::transform(grid.cbegin(), grid.cend(), frame_dowsampled.begin(),
-                   [](const auto &voxel_and_point) { return voxel_and_point.second; });
+    std::vector<Eigen::Vector3d> frame_dowsampled;
+    frame_dowsampled.reserve(grid.size());
+    std::for_each(grid.cbegin(), grid.cend(), [&](const auto &voxel_and_point) {
+        frame_dowsampled.emplace_back(voxel_and_point.second);
+    });
     return frame_dowsampled;
 }
 

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -35,18 +35,20 @@
 
 namespace kiss_icp {
 std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
-                                             const double voxel_size) {
-    tsl::robin_map<Voxel, Eigen::Vector3d> grid;
+                                             double voxel_size) {
+    tsl::robin_map<Voxel, Eigen::Vector3d, VoxelHash> grid;
     grid.reserve(frame.size());
-    std::for_each(frame.cbegin(), frame.cend(), [&](const auto &point) {
+    for (const auto &point : frame) {
         const auto voxel = PointToVoxel(point, voxel_size);
-        if (!grid.contains(voxel)) grid.insert({voxel, point});
-    });
+        if (grid.contains(voxel)) continue;
+        grid.insert({voxel, point});
+    }
     std::vector<Eigen::Vector3d> frame_dowsampled;
     frame_dowsampled.reserve(grid.size());
-    std::for_each(grid.cbegin(), grid.cend(), [&](const auto &voxel_and_point) {
-        frame_dowsampled.emplace_back(voxel_and_point.second);
-    });
+    for (const auto &[voxel, point] : grid) {
+        (void)voxel;
+        frame_dowsampled.emplace_back(point);
+    }
     return frame_dowsampled;
 }
 

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -32,34 +32,12 @@
 #include <sophus/se3.hpp>
 #include <vector>
 
-namespace {
-using Voxel = kiss_icp::VoxelHashMap::Voxel;
-using VoxelHash = kiss_icp::VoxelHashMap::VoxelHash;
-
-Voxel PointToVoxel(const Eigen::Vector3d &point, double voxel_size) {
-    return Voxel(static_cast<int>(std::floor(point.x() / voxel_size)),
-                 static_cast<int>(std::floor(point.y() / voxel_size)),
-                 static_cast<int>(std::floor(point.z() / voxel_size)));
-}
-}  // namespace
-
 namespace kiss_icp {
 std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
                                              double voxel_size) {
-    tsl::robin_map<Voxel, Eigen::Vector3d, VoxelHash> grid;
-    grid.reserve(frame.size());
-    for (const auto &point : frame) {
-        const auto voxel = PointToVoxel(point, voxel_size);
-        if (grid.contains(voxel)) continue;
-        grid.insert({voxel, point});
-    }
-    std::vector<Eigen::Vector3d> frame_dowsampled;
-    frame_dowsampled.reserve(grid.size());
-    for (const auto &[voxel, point] : grid) {
-        (void)voxel;
-        frame_dowsampled.emplace_back(point);
-    }
-    return frame_dowsampled;
+    VoxelHashMap grid(voxel_size, 1.0, 1);
+    grid.AddPoints(frame);
+    return grid.Pointcloud();
 }
 
 std::vector<Eigen::Vector3d> Preprocess(const std::vector<Eigen::Vector3d> &frame,

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -28,7 +28,6 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <cmath>
-#include <iterator>
 #include <sophus/se3.hpp>
 #include <vector>
 

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -28,6 +28,7 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <sophus/se3.hpp>
 #include <vector>
 
@@ -43,8 +44,10 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
         if (!grid.contains(voxel)) grid.insert({voxel, point});
     });
     std::vector<Eigen::Vector3d> frame_dowsampled(grid.size());
-    std::transform(grid.begin(), grid.end(), frame_dowsampled.begin(),
-                   [](const auto &voxel_and_point) { return voxel_and_point.second; });
+    std::transform(std::make_move_iterator(grid.begin()),  //
+                   std::make_move_iterator(grid.end()),    //
+                   frame_dowsampled.begin(),
+                   [](auto &&voxel_and_point) { return voxel_and_point.second; });
     return frame_dowsampled;
 }
 

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -44,10 +44,8 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
         if (!grid.contains(voxel)) grid.insert({voxel, point});
     });
     std::vector<Eigen::Vector3d> frame_dowsampled(grid.size());
-    std::transform(std::make_move_iterator(grid.begin()),  //
-                   std::make_move_iterator(grid.end()),    //
-                   frame_dowsampled.begin(),
-                   [](auto &&voxel_and_point) { return voxel_and_point.second; });
+    std::transform(grid.cbegin(), grid.cend(), frame_dowsampled.begin(),
+                   [](const auto &voxel_and_point) { return voxel_and_point.second; });
     return frame_dowsampled;
 }
 

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -28,18 +28,13 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <cmath>
+#include <kiss_icp/core/VoxelHashMap.hpp>
 #include <sophus/se3.hpp>
 #include <vector>
 
 namespace {
-// TODO(all): Maybe try to merge these voxel uitls with VoxelHashMap implementation
-using Voxel = Eigen::Vector3i;
-struct VoxelHash {
-    size_t operator()(const Voxel &voxel) const {
-        const uint32_t *vec = reinterpret_cast<const uint32_t *>(voxel.data());
-        return ((1 << 20) - 1) & (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
-    }
-};
+using Voxel = kiss_icp::VoxelHashMap::Voxel;
+using VoxelHash = kiss_icp::VoxelHashMap::VoxelHash;
 
 Voxel PointToVoxel(const Eigen::Vector3d &point, double voxel_size) {
     return Voxel(static_cast<int>(std::floor(point.x() / voxel_size)),

--- a/cpp/kiss_icp/core/Preprocessing.hpp
+++ b/cpp/kiss_icp/core/Preprocessing.hpp
@@ -30,7 +30,7 @@
 namespace kiss_icp {
 /// Voxelize point cloud keeping the original coordinates
 std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
-                                             double voxel_size);
+                                             const double voxel_size);
 
 /// Crop the frame with max/min ranges
 std::vector<Eigen::Vector3d> Preprocess(const std::vector<Eigen::Vector3d> &frame,

--- a/cpp/kiss_icp/core/Preprocessing.hpp
+++ b/cpp/kiss_icp/core/Preprocessing.hpp
@@ -28,9 +28,6 @@
 #include <vector>
 
 namespace kiss_icp {
-/// Voxelize point cloud keeping the original coordinates
-std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
-                                             const double voxel_size);
 
 /// Crop the frame with max/min ranges
 std::vector<Eigen::Vector3d> Preprocess(const std::vector<Eigen::Vector3d> &frame,
@@ -42,4 +39,7 @@ std::vector<Eigen::Vector3d> Preprocess(const std::vector<Eigen::Vector3d> &fram
 /// Originally introduced the calibration factor)
 std::vector<Eigen::Vector3d> CorrectKITTIScan(const std::vector<Eigen::Vector3d> &frame);
 
+/// Voxelize point cloud keeping the original coordinates
+std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
+                                             double voxel_size);
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -53,7 +53,7 @@ void TransformPoints(const Sophus::SE3d &T, std::vector<Eigen::Vector3d> &points
                    [&](const auto &point) { return T * point; });
 }
 
-using Voxel = kiss_icp::VoxelHashMap::Voxel;
+using Voxel = kiss_icp::Voxel;
 std::vector<Voxel> GetAdjacentVoxels(const Voxel &voxel, int adjacent_voxels = 1) {
     std::vector<Voxel> voxel_neighborhood;
     for (int i = voxel.x() - adjacent_voxels; i < voxel.x() + adjacent_voxels + 1; ++i) {
@@ -69,7 +69,7 @@ std::vector<Voxel> GetAdjacentVoxels(const Voxel &voxel, int adjacent_voxels = 1
 std::tuple<Eigen::Vector3d, double> GetClosestNeighbor(const Eigen::Vector3d &point,
                                                        const kiss_icp::VoxelHashMap &voxel_map) {
     // Convert the point to voxel coordinates
-    const auto &voxel = voxel_map.PointToVoxel(point);
+    const auto &voxel = kiss_icp::PointToVoxel(point, voxel_map.voxel_size_);
     // Get nearby voxels on the map
     const auto &query_voxels = GetAdjacentVoxels(voxel);
     // Extract the points contained within the neighborhood voxels

--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -36,6 +36,7 @@
 #include <tuple>
 
 #include "VoxelHashMap.hpp"
+#include "VoxelUtils.hpp"
 
 namespace Eigen {
 using Matrix6d = Eigen::Matrix<double, 6, 6>;

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -28,6 +28,8 @@
 #include <utility>
 #include <vector>
 
+#include "VoxelUtils.hpp"
+
 namespace kiss_icp {
 
 std::vector<Eigen::Vector3d> VoxelHashMap::GetPoints(const std::vector<Voxel> &query_voxels) const {

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -75,7 +75,7 @@ void VoxelHashMap::Update(const std::vector<Eigen::Vector3d> &points, const Soph
 
 void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
     std::for_each(points.cbegin(), points.cend(), [&](const auto &point) {
-        auto voxel = PointToVoxel(point);
+        auto voxel = PointToVoxel(point, voxel_size_);
         auto search = map_.find(voxel);
         if (search != map_.end()) {
             auto &voxel_block = search.value();

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -44,6 +44,7 @@ struct VoxelHashMap {
             if (points.size() < static_cast<size_t>(num_points_)) points.push_back(point);
         }
     };
+
     explicit VoxelHashMap(double voxel_size, double max_distance, int max_points_per_voxel)
         : voxel_size_(voxel_size),
           max_distance_(max_distance),
@@ -61,6 +62,6 @@ struct VoxelHashMap {
     double voxel_size_;
     double max_distance_;
     int max_points_per_voxel_;
-    tsl::robin_map<Voxel, VoxelBlock> map_;
+    tsl::robin_map<Voxel, VoxelBlock, VoxelHash> map_;
 };
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -29,12 +29,12 @@
 #include <tsl/robin_map.h>
 
 #include <Eigen/Core>
+#include <kiss_icp/core/VoxelUtils.hpp>
 #include <sophus/se3.hpp>
 #include <vector>
 
 namespace kiss_icp {
 struct VoxelHashMap {
-    using Voxel = Eigen::Vector3i;
     struct VoxelBlock {
         // buffer of points with a max limit of n_points
         std::vector<Eigen::Vector3d> points;
@@ -43,13 +43,6 @@ struct VoxelHashMap {
             if (points.size() < static_cast<size_t>(num_points_)) points.push_back(point);
         }
     };
-    struct VoxelHash {
-        size_t operator()(const Voxel &voxel) const {
-            const uint32_t *vec = reinterpret_cast<const uint32_t *>(voxel.data());
-            return (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
-        }
-    };
-
     explicit VoxelHashMap(double voxel_size, double max_distance, int max_points_per_voxel)
         : voxel_size_(voxel_size),
           max_distance_(max_distance),
@@ -57,11 +50,6 @@ struct VoxelHashMap {
 
     inline void Clear() { map_.clear(); }
     inline bool Empty() const { return map_.empty(); }
-    inline Voxel PointToVoxel(const Eigen::Vector3d &point) const {
-        return Voxel(static_cast<int>(std::floor(point.x() / voxel_size_)),
-                     static_cast<int>(std::floor(point.y() / voxel_size_)),
-                     static_cast<int>(std::floor(point.z() / voxel_size_)));
-    }
     void Update(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &origin);
     void Update(const std::vector<Eigen::Vector3d> &points, const Sophus::SE3d &pose);
     void AddPoints(const std::vector<Eigen::Vector3d> &points);
@@ -72,6 +60,6 @@ struct VoxelHashMap {
     double voxel_size_;
     double max_distance_;
     int max_points_per_voxel_;
-    tsl::robin_map<Voxel, VoxelBlock, VoxelHash> map_;
+    tsl::robin_map<Voxel, VoxelBlock> map_;
 };
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -29,9 +29,10 @@
 #include <tsl/robin_map.h>
 
 #include <Eigen/Core>
-#include <kiss_icp/core/VoxelUtils.hpp>
 #include <sophus/se3.hpp>
 #include <vector>
+
+#include "VoxelUtils.hpp"
 
 namespace kiss_icp {
 struct VoxelHashMap {

--- a/cpp/kiss_icp/core/VoxelUtils.hpp
+++ b/cpp/kiss_icp/core/VoxelUtils.hpp
@@ -23,9 +23,8 @@
 //
 #pragma once
 
-#include <bits/functional_hash.h>
-
 #include <Eigen/Core>
+#include <memory>
 
 namespace kiss_icp {
 using Voxel = Eigen::Vector3i;

--- a/cpp/kiss_icp/core/VoxelUtils.hpp
+++ b/cpp/kiss_icp/core/VoxelUtils.hpp
@@ -25,21 +25,21 @@
 
 #include <Eigen/Core>
 #include <cmath>
-#include <memory>
 
 namespace kiss_icp {
+
 using Voxel = Eigen::Vector3i;
+
 inline Voxel PointToVoxel(const Eigen::Vector3d &point, const double voxel_size) {
     return Voxel(static_cast<int>(std::floor(point.x() / voxel_size)),
                  static_cast<int>(std::floor(point.y() / voxel_size)),
                  static_cast<int>(std::floor(point.z() / voxel_size)));
 }
-}  // namespace kiss_icp
 
-template <>
-struct std::hash<kiss_icp::Voxel> {
-    std::size_t operator()(const kiss_icp::Voxel &voxel) const noexcept {
+struct VoxelHash {
+    size_t operator()(const Voxel &voxel) const {
         const uint32_t *vec = reinterpret_cast<const uint32_t *>(voxel.data());
         return (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
     }
 };
+}  // namespace kiss_icp

--- a/cpp/kiss_icp/core/VoxelUtils.hpp
+++ b/cpp/kiss_icp/core/VoxelUtils.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <cmath>
 #include <memory>
 
 namespace kiss_icp {


### PR DESCRIPTION
This unify the usage of ```Voxel``` and ```VoxelHash``` between ```Preprocessing``` and ```VoxelHashMap```, so that all the ```using``` are in one and one place only. 