### PR TITLE
Nacho/remove kitti from core library

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -22,13 +22,11 @@
 // SOFTWARE.
 #include "Preprocessing.hpp"
 
-#include <tbb/parallel_for.h>
 #include <tsl/robin_map.h>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <algorithm>
-#include <cmath>
 #include <vector>
 
 #include "VoxelUtils.hpp"
@@ -63,15 +61,4 @@ std::vector<Eigen::Vector3d> Preprocess(const std::vector<Eigen::Vector3d> &fram
     return inliers;
 }
 
-std::vector<Eigen::Vector3d> CorrectKITTIScan(const std::vector<Eigen::Vector3d> &frame) {
-    constexpr double VERTICAL_ANGLE_OFFSET = (0.205 * M_PI) / 180.0;
-    std::vector<Eigen::Vector3d> corrected_frame(frame.size());
-    tbb::parallel_for(size_t(0), frame.size(), [&](size_t i) {
-        const auto &pt = frame[i];
-        const Eigen::Vector3d rotationVector = pt.cross(Eigen::Vector3d(0., 0., 1.));
-        corrected_frame[i] =
-            Eigen::AngleAxisd(VERTICAL_ANGLE_OFFSET, rotationVector.normalized()) * pt;
-    });
-    return corrected_frame;
-}
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Preprocessing.hpp
+++ b/cpp/kiss_icp/core/Preprocessing.hpp
@@ -31,8 +31,4 @@ namespace kiss_icp {
 std::vector<Eigen::Vector3d> Preprocess(const std::vector<Eigen::Vector3d> &frame,
                                         double max_range,
                                         double min_range);
-
-/// Voxelize point cloud keeping the original coordinates
-std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
-                                             double voxel_size);
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Preprocessing.hpp
+++ b/cpp/kiss_icp/core/Preprocessing.hpp
@@ -32,11 +32,6 @@ std::vector<Eigen::Vector3d> Preprocess(const std::vector<Eigen::Vector3d> &fram
                                         double max_range,
                                         double min_range);
 
-/// This function only applies for the KITTI dataset, and should NOT be used by any other dataset,
-/// the original idea and part of the implementation is taking from CT-ICP(Although IMLS-SLAM
-/// Originally introduced the calibration factor)
-std::vector<Eigen::Vector3d> CorrectKITTIScan(const std::vector<Eigen::Vector3d> &frame);
-
 /// Voxelize point cloud keeping the original coordinates
 std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> &frame,
                                              double voxel_size);


### PR DESCRIPTION
## Remove KITTI scan correction from the core library

I'd love to get rid of the KITTI correction step from our CORE library, with the new changes in the voxelization, this makes more sense than ever

I also removed the tbb from the correction step, and the runtime was not impacted, and I don't care honestly.