### PR TITLE
Add LiDAR odometry to tf tree

### DIFF
--- a/ros/launch/odometry.launch.py
+++ b/ros/launch/odometry.launch.py
@@ -62,17 +62,18 @@ class config:
 def generate_launch_description():
     use_sim_time = LaunchConfiguration("use_sim_time", default="true")
 
-    # tf tree configuration, these are the likely 3 parameters to change and nothing else
-    base_frame = LaunchConfiguration("base_frame", default="")
-    odom_frame = LaunchConfiguration("odom_frame", default="odom")
-    publish_odom_tf = LaunchConfiguration("publish_odom_tf", default=True)
-
     # ROS configuration
     pointcloud_topic = LaunchConfiguration("topic")
     visualize = LaunchConfiguration("visualize", default="true")
 
     # Optional ros bag play
     bagfile = LaunchConfiguration("bagfile", default="")
+
+    # tf tree configuration, these are the likely parameters to change and nothing else
+    base_frame = LaunchConfiguration("base_frame", default="") # (base_link/base_footprint)
+    lidar_odom_frame = LaunchConfiguration("lidar_odom_frame", default="odom_lidar")
+    publish_odom_tf = LaunchConfiguration("publish_odom_tf", default=True)
+    invert_odom_tf = LaunchConfiguration("invert_odom_tf", default=True)
 
     # KISS-ICP node
     kiss_icp_node = Node(
@@ -87,8 +88,9 @@ def generate_launch_description():
             {
                 # ROS node configuration
                 "base_frame": base_frame,
-                "odom_frame": odom_frame,
+                "lidar_odom_frame": lidar_odom_frame,
                 "publish_odom_tf": publish_odom_tf,
+                "invert_odom_tf": invert_odom_tf,
                 # KISS-ICP configuration
                 "max_range": config.max_range,
                 "min_range": config.min_range,
@@ -123,10 +125,11 @@ def generate_launch_description():
     )
 
     bagfile_play = ExecuteProcess(
-        cmd=["ros2", "bag", "play", bagfile],
+        cmd=["ros2", "bag", "play", "--rate", "1", bagfile, "--clock", "1000.0"],
         output="screen",
         condition=IfCondition(PythonExpression(["'", bagfile, "' != ''"])),
     )
+
     return LaunchDescription(
         [
             kiss_icp_node,

--- a/ros/launch/odometry.launch.py
+++ b/ros/launch/odometry.launch.py
@@ -70,7 +70,7 @@ def generate_launch_description():
     bagfile = LaunchConfiguration("bagfile", default="")
 
     # tf tree configuration, these are the likely parameters to change and nothing else
-    base_frame = LaunchConfiguration("base_frame", default="") # (base_link/base_footprint)
+    base_frame = LaunchConfiguration("base_frame", default="")  # (base_link/base_footprint)
     lidar_odom_frame = LaunchConfiguration("lidar_odom_frame", default="odom_lidar")
     publish_odom_tf = LaunchConfiguration("publish_odom_tf", default=True)
     invert_odom_tf = LaunchConfiguration("invert_odom_tf", default=True)

--- a/ros/rviz/kiss_icp.rviz
+++ b/ros/rviz/kiss_icp.rviz
@@ -75,7 +75,7 @@ Visualization Manager:
           Color: 61; 229; 255
           Color Transformer: FlatColor
           Decay Time: 0
-          Enabled: true
+          Enabled: false
           Invert Rainbow: false
           Max Color: 255; 255; 255
           Max Intensity: 4096
@@ -96,7 +96,7 @@ Visualization Manager:
             Value: /kiss/keypoints
           Use Fixed Frame: true
           Use rainbow: true
-          Value: true
+          Value: false
         - Alpha: 1
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
@@ -133,60 +133,49 @@ Visualization Manager:
           Value: true
       Enabled: true
       Name: point_clouds
-    - Class: rviz_common/Group
-      Displays:
-        - Angle Tolerance: 0.10000000149011612
-          Class: rviz_default_plugins/Odometry
-          Covariance:
-            Orientation:
-              Alpha: 0.5
-              Color: 255; 255; 127
-              Color Style: Unique
-              Frame: Local
-              Offset: 1
-              Scale: 1
-              Value: true
-            Position:
-              Alpha: 0.30000001192092896
-              Color: 204; 51; 204
-              Scale: 1
-              Value: true
-            Value: true
-          Enabled: true
-          Keep: 100
-          Name: odometry
-          Position Tolerance: 0.10000000149011612
-          Shape:
-            Alpha: 1
-            Axes Length: 1
-            Axes Radius: 0.10000000149011612
-            Color: 255; 25; 0
-            Head Length: 0.30000001192092896
-            Head Radius: 0.10000000149011612
-            Shaft Length: 1
-            Shaft Radius: 0.05000000074505806
-            Value: Axes
-          Topic:
-            Depth: 5
-            Durability Policy: Volatile
-            Filter size: 10
-            History Policy: Keep Last
-            Reliability Policy: Best Effort
-            Value: /kiss/odometry
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz_default_plugins/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
           Value: true
-      Enabled: false
-      Name: odometry
-    - Class: rviz_default_plugins/Axes
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: false
       Enabled: true
-      Length: 1
-      Name: odom_frame
-      Radius: 0.10000000149011612
-      Reference Frame: odom
+      Keep: 100
+      Name: LiDAR Odometry
+      Position Tolerance: 0.10000000149011612
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 25; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Axes
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /kiss/odometry
       Value: true
   Enabled: true
   Global Options:
     Background Color: 0; 0; 0
-    Fixed Frame: odom
+    Fixed Frame: odom_lidar
     Frame Rate: 30
   Name: root
   Tools:
@@ -229,25 +218,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 178.319580078125
+      Distance: 51.88520812988281
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -68.01193237304688
-        Y: 258.05126953125
-        Z: -27.22064781188965
+        X: 0
+        Y: 0
+        Z: 0
       Focal Shape Fixed Size: false
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.49020177125930786
-      Target Frame: <Fixed Frame>
+      Pitch: 0.7853981852531433
+      Target Frame: odom_lidar
       Value: Orbit (rviz_default_plugins)
-      Yaw: 3.340390920639038
+      Yaw: 0.7853981852531433
     Saved: ~
 Window Geometry:
   Displays:

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -194,15 +194,13 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
 
 void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> frame,
                                    const std::vector<Eigen::Vector3d> keypoints,
-                                   const std_msgs::msg::Header &lidar_header) {
-    // The internal map representation is in the lidar_odom_frame_
-    std_msgs::msg::Header map_header;
-    map_header.frame_id = lidar_odom_frame_;
-    map_header.stamp = lidar_header.stamp;
+                                   const std_msgs::msg::Header &header) {
+    const auto kiss_map = kiss_icp_->LocalMap();
+    const auto kiss_pose = kiss_icp_->pose().inverse();
 
-    frame_publisher_->publish(std::move(EigenToPointCloud2(frame, lidar_header)));
-    kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, lidar_header)));
-    map_publisher_->publish(std::move(EigenToPointCloud2(kiss_icp_->LocalMap(), map_header)));
+    frame_publisher_->publish(std::move(EigenToPointCloud2(frame, header)));
+    kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, header)));
+    map_publisher_->publish(std::move(EigenToPointCloud2(kiss_map, kiss_pose, header)));
 }
 }  // namespace kiss_icp_ros
 

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -74,8 +74,9 @@ using utils::PointCloud2ToEigen;
 OdometryServer::OdometryServer(const rclcpp::NodeOptions &options)
     : rclcpp::Node("kiss_icp_node", options) {
     base_frame_ = declare_parameter<std::string>("base_frame", base_frame_);
-    odom_frame_ = declare_parameter<std::string>("odom_frame", odom_frame_);
+    lidar_odom_frame_ = declare_parameter<std::string>("lidar_odom_frame", lidar_odom_frame_);
     publish_odom_tf_ = declare_parameter<bool>("publish_odom_tf", publish_odom_tf_);
+    invert_odom_tf_ = declare_parameter<bool>("invert_odom_tf", invert_odom_tf_);
     publish_debug_clouds_ = declare_parameter<bool>("publish_debug_clouds", publish_debug_clouds_);
     position_covariance_ = declare_parameter<double>("position_covariance", 0.1);
     orientation_covariance_ = declare_parameter<double>("orientation_covariance", 0.1);
@@ -152,6 +153,7 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
     // If necessary, transform the ego-centric pose to the specified base_link/base_footprint frame
     const auto cloud_frame_id = header.frame_id;
     const auto egocentric_estimation = (base_frame_.empty() || base_frame_ == cloud_frame_id);
+    const auto moving_frame = egocentric_estimation ? cloud_frame_id : base_frame_;
     const auto pose = [&]() -> Sophus::SE3d {
         if (egocentric_estimation) return kiss_pose;
         const Sophus::SE3d cloud2base = LookupTransform(base_frame_, cloud_frame_id, tf2_buffer_);
@@ -162,16 +164,23 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
     if (publish_odom_tf_) {
         geometry_msgs::msg::TransformStamped transform_msg;
         transform_msg.header.stamp = header.stamp;
-        transform_msg.header.frame_id = odom_frame_;
-        transform_msg.child_frame_id = egocentric_estimation ? cloud_frame_id : base_frame_;
-        transform_msg.transform = tf2::sophusToTransform(pose);
+        if (invert_odom_tf_) {
+            transform_msg.header.frame_id = moving_frame;
+            transform_msg.child_frame_id = lidar_odom_frame_;
+            transform_msg.transform = tf2::sophusToTransform(pose.inverse());
+        } else {
+            transform_msg.header.frame_id = lidar_odom_frame_;
+            transform_msg.child_frame_id = moving_frame;
+            transform_msg.transform = tf2::sophusToTransform(pose);
+        }
         tf_broadcaster_->sendTransform(transform_msg);
     }
 
     // publish odometry msg
     nav_msgs::msg::Odometry odom_msg;
     odom_msg.header.stamp = header.stamp;
-    odom_msg.header.frame_id = odom_frame_;
+    odom_msg.header.frame_id = lidar_odom_frame_;
+    odom_msg.child_frame_id = moving_frame;
     odom_msg.pose.pose = tf2::sophusToPose(pose);
     odom_msg.pose.covariance.fill(0.0);
     odom_msg.pose.covariance[0] = position_covariance_;
@@ -185,13 +194,15 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
 
 void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> frame,
                                    const std::vector<Eigen::Vector3d> keypoints,
-                                   const std_msgs::msg::Header &header) {
-    const auto kiss_map = kiss_icp_->LocalMap();
-    const auto kiss_pose = kiss_icp_->pose().inverse();
+                                   const std_msgs::msg::Header &lidar_header) {
+    // The internal map representation is in the lidar_odom_frame_
+    std_msgs::msg::Header map_header;
+    map_header.frame_id = lidar_odom_frame_;
+    map_header.stamp = lidar_header.stamp;
 
-    frame_publisher_->publish(std::move(EigenToPointCloud2(frame, header)));
-    kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, header)));
-    map_publisher_->publish(std::move(EigenToPointCloud2(kiss_map, kiss_pose, header)));
+    frame_publisher_->publish(std::move(EigenToPointCloud2(frame, lidar_header)));
+    kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, lidar_header)));
+    map_publisher_->publish(std::move(EigenToPointCloud2(kiss_icp_->LocalMap(), map_header)));
 }
 }  // namespace kiss_icp_ros
 

--- a/ros/src/OdometryServer.hpp
+++ b/ros/src/OdometryServer.hpp
@@ -61,6 +61,7 @@ private:
     std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
     std::unique_ptr<tf2_ros::Buffer> tf2_buffer_;
     std::unique_ptr<tf2_ros::TransformListener> tf2_listener_;
+    bool invert_odom_tf_;
     bool publish_odom_tf_;
     bool publish_debug_clouds_;
 
@@ -77,7 +78,7 @@ private:
     std::unique_ptr<kiss_icp::pipeline::KissICP> kiss_icp_;
 
     /// Global/map coordinate frame.
-    std::string odom_frame_{"odom"};
+    std::string lidar_odom_frame_{"odom_lidar"};
     std::string base_frame_{};
 
     /// Covariance diagonal

--- a/ros/src/Utils.hpp
+++ b/ros/src/Utils.hpp
@@ -220,6 +220,16 @@ inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::
 }
 
 inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::Vector3d> &points,
+                                                       const Sophus::SE3d &T,
+                                                       const Header &header) {
+    std::vector<Eigen::Vector3d> points_t;
+    points_t.resize(points.size());
+    std::transform(points.cbegin(), points.cend(), points_t.begin(),
+                   [&](const auto &point) { return T * point; });
+    return EigenToPointCloud2(points_t, header);
+}
+
+inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::Vector3d> &points,
                                                        const std::vector<double> &timestamps,
                                                        const Header &header) {
     auto msg = CreatePointCloud2Msg(points.size(), header, true);

--- a/ros/src/Utils.hpp
+++ b/ros/src/Utils.hpp
@@ -220,16 +220,6 @@ inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::
 }
 
 inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::Vector3d> &points,
-                                                       const Sophus::SE3d &T,
-                                                       const Header &header) {
-    std::vector<Eigen::Vector3d> points_t;
-    points_t.resize(points.size());
-    std::transform(points.cbegin(), points.cend(), points_t.begin(),
-                   [&](const auto &point) { return T * point; });
-    return EigenToPointCloud2(points_t, header);
-}
-
-inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::Vector3d> &points,
                                                        const std::vector<double> &timestamps,
                                                        const Header &header) {
     auto msg = CreatePointCloud2Msg(points.size(), header, true);


### PR DESCRIPTION
# Why do we publish the inverted pose in the tf tree

KISS ICP  takes an input point cloud in the lidar frame/robot  frame and estimates the pose of the lidar/robot incrementally.  This, in tf parlance, will read as (taking the robot frame as example):

> KISS ICP, given an input cloud in the base_frame, will estimate the transformation from an odometric frame "odom_lidar" to the "base_link". Basically odom_lidar -> base_link

<img src="https://github.com/user-attachments/assets/186de9f0-640e-460f-ac60-820b25869536" width="300">

As a reminder, a wheel odometry node will do something similar. Given the encoder readings, the wheel odometer will produce the transformation from an odometric frame "odom" to the base_link:

<img src="https://github.com/user-attachments/assets/307ed2cc-5dd1-424b-9be4-46f4a4ca67ee" width="300">

Ok, fantastic, but what happens if we now want to publish these two transformations to the tf tree? This is how the final tf tree would look like:

<img src="https://github.com/user-attachments/assets/3e6c8eef-cbbe-40f3-b77d-f0d3b6e89936" width="300">

It turns out that the tf2 implementation, by design ( [REP-105](https://www.ros.org/reps/rep-0105.html)):

> We have chosen a tree representation to attach all coordinate frames in a robot system to each other. Therefore each coordinate frame has one parent coordinate frame, and any number of child coordinate frames. 

Which means that the tree you dreamed about is not possible. For two years at KISS-ICP, I needed help figuring out how to solve this issue, and then, we did not publish ANY lidar odometry output to the tf tree. You can't just spin a TF2 listener and look for transformations from the LiDAR odometry system with interpolation, time travel, and all the excellent tools TF2 provides us. In the past, I even tried to hack it around by publishing [alias transformations](https://github.com/PRBonn/kiss-icp/blob/71a6a0bb4058d75422a6369a110c5547564bcd6b/ros/ros2/OdometryServer.cpp#L86-L102), which was horrible and not working.   This topic was already discussed at https://github.com/ros/geometry2/issues/437

## The solution: Inject an inverted transformation in the tf tree

Our beloved William realized that if you add not the transformation we compute but the inverse of that (base_link -> odom_lidar), then this is not violating at all the tf conventions:

<img src="https://github.com/user-attachments/assets/134de285-b735-4208-b2fc-f70a681eded2" width="300">


This has many benefits:

1. We finally have the lidar odometry estimation in the tf tree, so go wild now with your lookups!
2. ~No more nasty hacks in the visualization pipeline to make sure we can see the clouds (get the kiss map, convert back to lidar frame using `kiss_icp.pose().inverse()` and put a fake header on this msg.~ WIP
3. Transparent `tf2::lookUpTransform` Since `tf2_buffer->lookupTransform(target_frame, source_frame`, we can do `tf2_buffer->lookupTransform("odom_lidar", "base_link)`, and this will give us the last LiDAR odometry pose. Ture, internally the tf2 buffer will need to invert the transformation that has coded inside, so `inverse(tf2_buffer->lookupTransform("base_link", "odom_lidar")`, but this is transparent to the user and doesn't even need to know

 The only disadvantages I see are

1.  Let's compute the lidar odometry pose and then query it in another ROS node (the last one for this example). Then, first we `PublishOdom(pose.inverse()` and then when querying with the tf `return inverse(pose.inverse())` which might introduce some numerical errors
2. If you inspect the `/tf` and see inside the tf RAW, the transformation you are looking at is inverted, so you can't just plot it with plotjuggler. Let's say you will always need to post-process it and invert it; this information is barely present in the `frame_id` and `child_frame_id` inside the tf message; it's clear, but it might be confusing.

## Changes

- `invert_odom_tf`: Introduce a new boolean flag,  `true` by default, to control in the feature whether we want or not to internally publish the inverted transformation through the tf tree. An example would be: the wheel odometry is not part of the tf tree, or we don't have any wheel odometry. Or tf now support multiple parents' IDs? It doesn't matter, but as the proposed solution is slightly hacky, it's fair to guard it with a configurable flag.
- Change `rviz2` default "Fixed Frame" to `odom_lidar`. A true dream come true! We don't even need to know what the frames are in the robot system; 100% of the frames are defined at launch time, and everything is now tightly coupled in the tf tree.
- Now we have a valid tf tree! We can use Rviz for whatever we want; all visualizations are now constantly working, which I did not manage to fix in https://github.com/PRBonn/kiss-icp/pull/285. Now the frames are always displaying the clouds, the odometry message, etc, no matter what fixed frame you pick for visualizing. Of course I set `odom_lidar` by default

##  Related discussions

- https://ctu-mrs.github.io/docs/system/frames_of_reference.html#multi-frame-localization-problem
-  https://github.com/ros/geometry2/issues/437
- https://discourse.ros.org/t/map-base-odom-as-alternative-for-rep-105-recommended-frame-order/25095/1

## Open questions

-  I made aeb1cf4dbc5f77301454688ffe8a91aa9037177f work for my case, for for mainstream kiss-icp is not working (I think yet again I might be missing something). I don't mind keeping this transformation, but it's something that surprised me

## Ack

This idea was proposed by William the Great, aka @doisyg , so kudos to him for this kick-ass idea that has been hunting me for months!