### PR TITLE
Fix EXISTS resolves symlinks but add_subdirectory does not

### DIFF
--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -25,7 +25,7 @@ project(kiss_icp VERSION 1.0.0 LANGUAGES CXX)
 
 set(CMAKE_BUILD_TYPE Release)
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/kiss_icp/)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/kiss_icp/ AND NOT IS_SYMLINK ${CMAKE_CURRENT_SOURCE_DIR})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp/kiss_icp ${CMAKE_CURRENT_BINARY_DIR}/kiss_icp)
 else()
   cmake_minimum_required(VERSION 3.18)


### PR DESCRIPTION
Our tooling typically clones projects in symlinked directories where the `EXISTS` and `add_subdirectory` logic doesn't work out of the box.
This way it does!