### PR TITLE
Tiziano/Add inner Voxel resolution 

### DIFF
--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -36,16 +36,7 @@
 
 namespace kiss_icp {
 struct VoxelHashMap {
-    struct VoxelBlock {
-        // buffer of points with a max limit of n_points
-        std::vector<Eigen::Vector3d> points;
-        int num_points_;
-        inline void AddPoint(const Eigen::Vector3d &point) {
-            if (points.size() < static_cast<size_t>(num_points_)) points.push_back(point);
-        }
-    };
-
-    explicit VoxelHashMap(double voxel_size, double max_distance, int max_points_per_voxel)
+    explicit VoxelHashMap(double voxel_size, double max_distance, unsigned int max_points_per_voxel)
         : voxel_size_(voxel_size),
           max_distance_(max_distance),
           max_points_per_voxel_(max_points_per_voxel) {}
@@ -61,7 +52,7 @@ struct VoxelHashMap {
 
     double voxel_size_;
     double max_distance_;
-    int max_points_per_voxel_;
-    tsl::robin_map<Voxel, VoxelBlock> map_;
+    unsigned int max_points_per_voxel_;
+    tsl::robin_map<Voxel, std::vector<Eigen::Vector3d>> map_;
 };
 }  // namespace kiss_icp


### PR DESCRIPTION
This PR aims to follow up on our discussion among the KISS core team about making the points contained in our beloved ```VoxelHashMap``` effective for data association. 

My proposal here is to have points equally spaced into each voxel. Based on the fact that our 3d world can be represented as a set of (locally) 2d surfaces, we can compute the desired minimum distance between points (from now on called ```map_resolution```) without adding parameter via:

$$\text{map resolution} = \sqrt(\frac{\text{voxel size}*\text{voxel size}}{\text{max points per voxel}})$$

I will now proceed to benchmark and update this PR on-demand so that we have a record of what happened.