### PR TITLE
Tiziano/Inner voxel resolution

### DIFF
--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -71,14 +71,20 @@ void VoxelHashMap::Update(const std::vector<Eigen::Vector3d> &points, const Soph
 }
 
 void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
+    const double map_resolution = std::sqrt(voxel_size_ * voxel_size_ / max_points_per_voxel_);
     std::for_each(points.cbegin(), points.cend(), [&](const auto &point) {
         auto voxel = PointToVoxel(point, voxel_size_);
         auto search = map_.find(voxel);
         if (search != map_.end()) {
             auto &voxel_points = search.value();
-            if (voxel_points.size() < max_points_per_voxel_) {
-                voxel_points.emplace_back(point);
+            if (voxel_points.size() == max_points_per_voxel_ ||
+                std::any_of(voxel_points.cbegin(), voxel_points.cend(),
+                            [&](const auto &voxel_point) {
+                                return (voxel_point - point).norm() < map_resolution;
+                            })) {
+                return;
             }
+            voxel_points.emplace_back(point);
         } else {
             std::vector<Eigen::Vector3d> voxel_points;
             voxel_points.reserve(max_points_per_voxel_);


### PR DESCRIPTION
This PR aims to follow up on our discussion among the KISS core team about making the points contained in our beloved ```VoxelHashMap``` effective for data association.

My proposal here is to have points equally spaced into each voxel. Based on the fact that our 3d world can be represented as a set of (locally) 2d surfaces, we can compute the desired minimum distance between points (from now on called ```map_resolution```) without adding parameter via:

$$\text{map resolution} = \sqrt(\frac{\text{voxel size}*\text{voxel size}}{\text{max points per voxel}})$$

Here I post the benchmark results:

![comparison](https://github.com/user-attachments/assets/3d70095a-dc1c-4e12-8fb4-e20a059d9044)
