### PR TITLE
Add draft visualization for the voxels of the VoxelHashMap

### DIFF
--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -58,17 +58,9 @@ std::vector<Eigen::Vector3d> VoxelHashMap::Pointcloud() const {
 
 // Get the indices of the occupided voxels as points, mainly used for visualization
 std::vector<Voxel> VoxelHashMap::GetVoxels() const {
-std::vector<Voxel> voxels(map_.size());
+    std::vector<Voxel> voxels(map_.size());
     std::transform(map_.cbegin(), map_.cend(), voxels.begin(),
                    [](const auto &map_element) { return map_element.first; });
-    return voxels;
-}
-    std::vector<Voxel> voxels;
-    voxels.reserve(map_.size());
-    for (const auto &[voxel, voxel_block] : map_) {
-        (void)voxel_block;
-        voxels.emplace_back(voxel);
-    }
     return voxels;
 }
 

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -56,6 +56,17 @@ std::vector<Eigen::Vector3d> VoxelHashMap::Pointcloud() const {
     return points;
 }
 
+// Get the indices of the occupided voxels as points, mainly used for visualization
+std::vector<Voxel> VoxelHashMap::GetVoxels() const {
+    std::vector<Voxel> voxels;
+    voxels.reserve(map_.size());
+    for (const auto &[voxel, voxel_block] : map_) {
+        (void)voxel_block;
+        voxels.emplace_back(voxel);
+    }
+    return voxels;
+}
+
 void VoxelHashMap::Update(const std::vector<Eigen::Vector3d> &points,
                           const Eigen::Vector3d &origin) {
     AddPoints(points);

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -58,6 +58,11 @@ std::vector<Eigen::Vector3d> VoxelHashMap::Pointcloud() const {
 
 // Get the indices of the occupided voxels as points, mainly used for visualization
 std::vector<Voxel> VoxelHashMap::GetVoxels() const {
+std::vector<Voxel> voxels(map_.size());
+    std::transform(map_.cbegin(), map_.cend(), voxels.begin(),
+                   [](const auto &map_element) { return map_element.first; });
+    return voxels;
+}
     std::vector<Voxel> voxels;
     voxels.reserve(map_.size());
     for (const auto &[voxel, voxel_block] : map_) {

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -49,6 +49,7 @@ struct VoxelHashMap {
     void RemovePointsFarFromLocation(const Eigen::Vector3d &origin);
     std::vector<Eigen::Vector3d> Pointcloud() const;
     std::vector<Eigen::Vector3d> GetPoints(const std::vector<Voxel> &query_voxels) const;
+    std::vector<Voxel> GetVoxels() const;
 
     double voxel_size_;
     double max_distance_;

--- a/python/kiss_icp/mapping.py
+++ b/python/kiss_icp/mapping.py
@@ -66,3 +66,7 @@ class VoxelHashMap:
     def point_cloud(self) -> np.ndarray:
         """Return the internal representaion as a np.array (pointcloud)."""
         return np.asarray(self._internal_map._point_cloud())
+
+    def get_voxels(self) -> np.ndarray:
+        """Return the occupied voxels, in indices (i,j,k( as a np.array."""
+        return np.asarray(self._internal_map._get_voxels())

--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -77,6 +77,7 @@ class OdometryPipeline:
 
         # Visualizer
         self.visualizer = RegistrationVisualizer() if visualize else StubVisualizer()
+        self.visualizer.voxel_size = self.config.mapping.voxel_size
         if hasattr(self._dataset, "use_global_visualizer"):
             self.visualizer.global_view = self._dataset.use_global_visualizer
 

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -72,7 +72,8 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
             "points"_a, "pose"_a)
         .def("_add_points", &VoxelHashMap::AddPoints, "points"_a)
         .def("_remove_far_away_points", &VoxelHashMap::RemovePointsFarFromLocation, "origin"_a)
-        .def("_point_cloud", &VoxelHashMap::Pointcloud);
+        .def("_point_cloud", &VoxelHashMap::Pointcloud)
+        .def("_get_voxels", &VoxelHashMap::GetVoxels);
 
     // Point Cloud registration
     py::class_<Registration> internal_registration(m, "_Registration", "Don't use this");


### PR DESCRIPTION
WIP

This is a new idea to visualize the internal map representation of kiss icp besides the pointcloud stored in the hash table.
@l00p3 do you think something like this would be possible with the new visualizer?

The current Open3D API for `VoxelGrid` is not that rich, and it makes rendering a bit slow when the grid is requested, so I'd be more than happy to migrate so something better.

![image](https://github.com/user-attachments/assets/1e3f089c-6e7b-4e39-bee9-6d852a725021)
