### PR TITLE
Move NN search back to the VoxelHashMap

### DIFF
--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -55,41 +55,6 @@ void TransformPoints(const Sophus::SE3d &T, std::vector<Eigen::Vector3d> &points
                    [&](const auto &point) { return T * point; });
 }
 
-using Voxel = kiss_icp::Voxel;
-std::vector<Voxel> GetAdjacentVoxels(const Voxel &voxel, int adjacent_voxels = 1) {
-    std::vector<Voxel> voxel_neighborhood;
-    for (int i = voxel.x() - adjacent_voxels; i < voxel.x() + adjacent_voxels + 1; ++i) {
-        for (int j = voxel.y() - adjacent_voxels; j < voxel.y() + adjacent_voxels + 1; ++j) {
-            for (int k = voxel.z() - adjacent_voxels; k < voxel.z() + adjacent_voxels + 1; ++k) {
-                voxel_neighborhood.emplace_back(i, j, k);
-            }
-        }
-    }
-    return voxel_neighborhood;
-}
-
-std::tuple<Eigen::Vector3d, double> GetClosestNeighbor(const Eigen::Vector3d &point,
-                                                       const kiss_icp::VoxelHashMap &voxel_map) {
-    // Convert the point to voxel coordinates
-    const auto &voxel = kiss_icp::PointToVoxel(point, voxel_map.voxel_size_);
-    // Get nearby voxels on the map
-    const auto &query_voxels = GetAdjacentVoxels(voxel);
-    // Extract the points contained within the neighborhood voxels
-    const auto &neighbors = voxel_map.GetPoints(query_voxels);
-
-    // Find the nearest neighbor
-    Eigen::Vector3d closest_neighbor = Eigen::Vector3d::Zero();
-    double closest_distance = std::numeric_limits<double>::max();
-    std::for_each(neighbors.cbegin(), neighbors.cend(), [&](const auto &neighbor) {
-        double distance = (neighbor - point).norm();
-        if (distance < closest_distance) {
-            closest_neighbor = neighbor;
-            closest_distance = distance;
-        }
-    });
-    return std::make_tuple(closest_neighbor, closest_distance);
-}
-
 Correspondences DataAssociation(const std::vector<Eigen::Vector3d> &points,
                                 const kiss_icp::VoxelHashMap &voxel_map,
                                 const double max_correspondance_distance) {
@@ -105,7 +70,7 @@ Correspondences DataAssociation(const std::vector<Eigen::Vector3d> &points,
         [&](const tbb::blocked_range<points_iterator> &r, Correspondences res) -> Correspondences {
             res.reserve(r.size());
             std::for_each(r.begin(), r.end(), [&](const auto &point) {
-                const auto &[closest_neighbor, distance] = GetClosestNeighbor(point, voxel_map);
+                const auto &[closest_neighbor, distance] = voxel_map.GetClosestNeighbor(point);
                 if (distance < max_correspondance_distance) {
                     res.emplace_back(point, closest_neighbor);
                 }

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -29,20 +29,59 @@
 
 #include "VoxelUtils.hpp"
 
-namespace kiss_icp {
+namespace {
+using kiss_icp::Voxel;
 
-std::vector<Eigen::Vector3d> VoxelHashMap::GetPoints(const std::vector<Voxel> &query_voxels) const {
+std::vector<Voxel> GetAdjacentVoxels(const Voxel &voxel, int adjacent_voxels = 1) {
+    std::vector<Voxel> voxel_neighborhood;
+    for (int i = voxel.x() - adjacent_voxels; i < voxel.x() + adjacent_voxels + 1; ++i) {
+        for (int j = voxel.y() - adjacent_voxels; j < voxel.y() + adjacent_voxels + 1; ++j) {
+            for (int k = voxel.z() - adjacent_voxels; k < voxel.z() + adjacent_voxels + 1; ++k) {
+                voxel_neighborhood.emplace_back(i, j, k);
+            }
+        }
+    }
+    return voxel_neighborhood;
+}
+std::vector<Eigen::Vector3d> GetPoints(const std::vector<Voxel> &query_voxels,
+                                       const kiss_icp::VoxelHashMap &voxel_map) {
     std::vector<Eigen::Vector3d> points;
-    points.reserve(query_voxels.size() * static_cast<size_t>(max_points_per_voxel_));
+    points.reserve(query_voxels.size() * static_cast<size_t>(voxel_map.max_points_per_voxel_));
     std::for_each(query_voxels.cbegin(), query_voxels.cend(), [&](const auto &query) {
-        auto search = map_.find(query);
-        if (search != map_.end()) {
+        auto search = voxel_map.map_.find(query);
+        if (search != voxel_map.map_.end()) {
             const auto &voxel_points = search.value();
             points.insert(points.end(), voxel_points.cbegin(), voxel_points.cend());
         }
     });
     points.shrink_to_fit();
     return points;
+}
+
+}  // namespace
+
+namespace kiss_icp {
+
+std::tuple<Eigen::Vector3d, double> VoxelHashMap::GetClosestNeighbor(
+    const Eigen::Vector3d &point) const {
+    // Convert the point to voxel coordinates
+    const auto &voxel = kiss_icp::PointToVoxel(point, voxel_size_);
+    // Get nearby voxels on the map
+    const auto &query_voxels = GetAdjacentVoxels(voxel);
+    // Extract the points contained within the neighborhood voxels
+    const auto &neighbors = GetPoints(query_voxels, *this);
+
+    // Find the nearest neighbor
+    Eigen::Vector3d closest_neighbor = Eigen::Vector3d::Zero();
+    double closest_distance = std::numeric_limits<double>::max();
+    std::for_each(neighbors.cbegin(), neighbors.cend(), [&](const auto &neighbor) {
+        double distance = (neighbor - point).norm();
+        if (distance < closest_distance) {
+            closest_neighbor = neighbor;
+            closest_distance = distance;
+        }
+    });
+    return std::make_tuple(closest_neighbor, closest_distance);
 }
 
 std::vector<Eigen::Vector3d> VoxelHashMap::Pointcloud() const {

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -65,7 +65,7 @@ namespace kiss_icp {
 std::tuple<Eigen::Vector3d, double> VoxelHashMap::GetClosestNeighbor(
     const Eigen::Vector3d &point) const {
     // Convert the point to voxel coordinates
-    const auto &voxel = kiss_icp::PointToVoxel(point, voxel_size_);
+    const auto &voxel = PointToVoxel(point, voxel_size_);
     // Get nearby voxels on the map
     const auto &query_voxels = GetAdjacentVoxels(voxel);
     // Extract the points contained within the neighborhood voxels

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -48,7 +48,7 @@ struct VoxelHashMap {
     void AddPoints(const std::vector<Eigen::Vector3d> &points);
     void RemovePointsFarFromLocation(const Eigen::Vector3d &origin);
     std::vector<Eigen::Vector3d> Pointcloud() const;
-    std::vector<Eigen::Vector3d> GetPoints(const std::vector<Voxel> &query_voxels) const;
+    std::tuple<Eigen::Vector3d, double> GetClosestNeighbor(const Eigen::Vector3d &point) const;
 
     double voxel_size_;
     double max_distance_;


### PR DESCRIPTION
I simply moved the functions related to the Nearest Neighbor search from ```Registration``` to ```VoxelHashMap```, as this is the data structure that is used to compute the neighbors. This allows other people to use our same strategy of NN search without copy-pasting code from an unnamed namespace. I know that this is something we did a long time ago, but I changed my mind, and this makes much more sense, as now you can use our NN search decoupled from the registration module. Of course, performances are completely unaffected, as I can show here.

![comparison](https://github.com/user-attachments/assets/460a4348-e682-47a7-8b5b-998a14c8a7b2)


Ps: this change is propedeutic (io non parlo inglese) to a slightly more significant change that will remove a useless copy of points from the voxels during the NN search.

## Related PRs

This PR basically shadows what we did in https://github.com/PRBonn/kiss-icp/pull/290 when we refactored a bit the system to support different number of threads in https://github.com/PRBonn/kiss-icp/pull/252