### PR TITLE
Remove unused header

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -29,8 +29,6 @@
 #include <algorithm>
 #include <vector>
 
-#include "VoxelUtils.hpp"
-
 namespace kiss_icp {
 std::vector<Eigen::Vector3d> Preprocess(const std::vector<Eigen::Vector3d> &frame,
                                         double max_range,


### PR DESCRIPTION
This header is probably a leftover from the many refactoring PRs. I can't trace it down, but it's not being used, so it's safe to remove.

I'm trying to marry internal branches with main kiss-icp and this is only visually bothering me (as it artificially increased the  git diff)