### PR TITLE
Nacho/GitHub linguistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.cpp linguist-language=C++
+*.hpp linguist-language=C++
+*.md linguist-documentation
+*.py linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.hpp linguist-language=C++
 *.md linguist-documentation
 *.py linguist-vendored
+*.ipynb linguist-vendored


### PR DESCRIPTION
Override github linguistics

kiss-icp is mainly a C++ project with Python wrappers; we support so many dataloaders in Python that GitHub thinks it's a Python codebase instead.

![image](https://github.com/user-attachments/assets/ff0b4e59-0856-4c95-82e5-4b4f96f2fe77)

I ran this locally and this is the new output
```
github-linguist .

83.78%  C++
15.87%  CMake
0.35%   Makefile
```