### PR TITLE
Fix issue in the read_ros2_messages calling

### DIFF
--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -46,7 +46,7 @@ class McapDataloader:
         self.summary = self.bag.get_summary()
         self.topic = self.check_topic(topic)
         self.n_scans = self._get_n_scans()
-        self.msgs = read_ros2_messages(mcap_file, topics=self.topic)
+        self.msgs = read_ros2_messages(mcap_file, topics=[self.topic])
         self.timestamps = []
         self.read_point_cloud = read_point_cloud
         self.use_global_visualizer = True


### PR DESCRIPTION
read_ros2_messages function takes a list of topics as input. In some cases, this may be a problem. As in this case, I executed it by simply typing: `kiss_icp_pipeline /home/leonardo/tesla_dataset/rosbag2_2023_11_18-14_56_27_0.mcap`
![Screenshot from 2024-09-13 11-48-10](https://github.com/user-attachments/assets/0bfb75d9-9af4-4c1e-8592-3401de599132)