### PR TITLE
Add param to force planarity

### DIFF
--- a/config/advanced.yaml
+++ b/config/advanced.yaml
@@ -21,3 +21,4 @@ registration:
   max_num_iterations: 500 # <- optional
   convergence_criterion: 0.0001 # <- optional
   max_num_threads: 0 # <- optional, 0 means automatic
+  planar: false # if true, 2D registration is forced (z, roll, and pitch are zeroed)

--- a/cpp/kiss_icp/core/Registration.hpp
+++ b/cpp/kiss_icp/core/Registration.hpp
@@ -31,7 +31,10 @@
 namespace kiss_icp {
 
 struct Registration {
-    explicit Registration(int max_num_iteration, double convergence_criterion, int max_num_threads);
+    explicit Registration(int max_num_iteration,
+                          double convergence_criterion,
+                          int max_num_threads,
+                          bool planar);
 
     Sophus::SE3d AlignPointsToMap(const std::vector<Eigen::Vector3d> &frame,
                                   const VoxelHashMap &voxel_map,
@@ -42,5 +45,6 @@ struct Registration {
     int max_num_iterations_;
     double convergence_criterion_;
     int max_num_threads_;
+    bool planar_;
 };
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -50,6 +50,9 @@ struct KISSConfig {
 
     // Motion compensation
     bool deskew = false;
+
+    // 2D Mode
+    bool planar = false;
 };
 
 class KissICP {
@@ -60,8 +63,10 @@ public:
 public:
     explicit KissICP(const KISSConfig &config)
         : config_(config),
-          registration_(
-              config.max_num_iterations, config.convergence_criterion, config.max_num_threads),
+          registration_(config.max_num_iterations,
+                        config.convergence_criterion,
+                        config.max_num_threads,
+                        config.planar),
           local_map_(config.voxel_size, config.max_range, config.max_points_per_voxel),
           adaptive_threshold_(config.initial_threshold, config.min_motion_th, config.max_range) {}
 

--- a/python/kiss_icp/config/config.py
+++ b/python/kiss_icp/config/config.py
@@ -40,6 +40,7 @@ class RegistrationConfig(BaseModel):
     max_num_iterations: Optional[int] = 500
     convergence_criterion: Optional[float] = 0.0001
     max_num_threads: Optional[int] = 0  # 0 means automatic
+    planar: Optional[bool] = False
 
 
 class AdaptiveThresholdConfig(BaseModel):

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -77,8 +77,8 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
     // Point Cloud registration
     py::class_<Registration> internal_registration(m, "_Registration", "Don't use this");
     internal_registration
-        .def(py::init<int, double, int>(), "max_num_iterations"_a, "convergence_criterion"_a,
-             "max_num_threads"_a)
+        .def(py::init<int, double, int, bool>(), "max_num_iterations"_a, "convergence_criterion"_a,
+             "max_num_threads"_a, "planar"_a)
         .def(
             "_align_points_to_map",
             [](Registration &self, const std::vector<Eigen::Vector3d> &points,

--- a/python/kiss_icp/registration.py
+++ b/python/kiss_icp/registration.py
@@ -41,6 +41,7 @@ class Registration:
         max_num_iterations: int,
         convergence_criterion: float,
         max_num_threads: int = 0,
+        planar: bool = False,
     ):
         self._registration = kiss_icp_pybind._Registration(
             max_num_iterations=max_num_iterations,


### PR DESCRIPTION
There is probably a smarter way to do this, but for some environments it can be useful to have "2.5D" odometry. This just sets the z axis and roll and pitch angles to zero during registration