### PR TITLE
Use relative names for topics

### DIFF
--- a/ros/rviz/kiss_icp.rviz
+++ b/ros/rviz/kiss_icp.rviz
@@ -59,7 +59,7 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Best Effort
-            Value: /kiss/frame
+            Value: kiss/frame
           Use Fixed Frame: true
           Use rainbow: true
           Value: true
@@ -93,7 +93,7 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Best Effort
-            Value: /kiss/keypoints
+            Value: kiss/keypoints
           Use Fixed Frame: true
           Use rainbow: true
           Value: false
@@ -127,7 +127,7 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Best Effort
-            Value: /kiss/local_map
+            Value: kiss/local_map
           Use Fixed Frame: true
           Use rainbow: true
           Value: true
@@ -170,7 +170,7 @@ Visualization Manager:
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Best Effort
-        Value: /kiss/odometry
+        Value: kiss/odometry
       Value: true
   Enabled: true
   Global Options:

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -115,8 +115,7 @@ OdometryServer::OdometryServer(const rclcpp::NodeOptions &options)
     odom_publisher_ = create_publisher<nav_msgs::msg::Odometry>("kiss/odometry", qos);
     if (publish_debug_clouds_) {
         frame_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("kiss/frame", qos);
-        kpoints_publisher_ =
-            create_publisher<sensor_msgs::msg::PointCloud2>("kiss/keypoints", qos);
+        kpoints_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("kiss/keypoints", qos);
         map_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("kiss/local_map", qos);
     }
 

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -112,12 +112,12 @@ OdometryServer::OdometryServer(const rclcpp::NodeOptions &options)
 
     // Initialize publishers
     rclcpp::QoS qos((rclcpp::SystemDefaultsQoS().keep_last(1).durability_volatile()));
-    odom_publisher_ = create_publisher<nav_msgs::msg::Odometry>("/kiss/odometry", qos);
+    odom_publisher_ = create_publisher<nav_msgs::msg::Odometry>("kiss/odometry", qos);
     if (publish_debug_clouds_) {
-        frame_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("/kiss/frame", qos);
+        frame_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("kiss/frame", qos);
         kpoints_publisher_ =
-            create_publisher<sensor_msgs::msg::PointCloud2>("/kiss/keypoints", qos);
-        map_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("/kiss/local_map", qos);
+            create_publisher<sensor_msgs::msg::PointCloud2>("kiss/keypoints", qos);
+        map_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("kiss/local_map", qos);
     }
 
     // Initialize the transform broadcaster


### PR DESCRIPTION
Quick PR to address issue #414

Tested locally, if you run kiss_icp without a namespace everything stays as before this PR, if a namespace is specified messages are published on namespace/kiss/

Also updated the .rviz config to match this modifications and also allow to run rviz with a namespace.