### PR TITLE
Publish map in odom_lidar frame

### DIFF
--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -200,7 +200,10 @@ void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> frame,
 
     frame_publisher_->publish(std::move(EigenToPointCloud2(frame, header)));
     kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, header)));
-    map_publisher_->publish(std::move(EigenToPointCloud2(kiss_map, kiss_pose, header)));
+
+    auto local_map_header = header;
+    local_map_header.frame_id = lidar_odom_frame_;
+    map_publisher_->publish(std::move(EigenToPointCloud2(kiss_map, local_map_header)));
 }
 }  // namespace kiss_icp_ros
 

--- a/ros/src/Utils.hpp
+++ b/ros/src/Utils.hpp
@@ -228,4 +228,13 @@ inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::
                    [&](const auto &point) { return T * point; });
     return EigenToPointCloud2(points_t, header);
 }
+
+inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::Vector3d> &points,
+                                                       const std::vector<double> &timestamps,
+                                                       const Header &header) {
+    auto msg = CreatePointCloud2Msg(points.size(), header, true);
+    FillPointCloud2XYZ(points, *msg);
+    FillPointCloud2Timestamp(timestamps, *msg);
+    return msg;
+}
 }  // namespace kiss_icp_ros::utils

--- a/ros/src/Utils.hpp
+++ b/ros/src/Utils.hpp
@@ -228,13 +228,4 @@ inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::
                    [&](const auto &point) { return T * point; });
     return EigenToPointCloud2(points_t, header);
 }
-
-inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::Vector3d> &points,
-                                                       const std::vector<double> &timestamps,
-                                                       const Header &header) {
-    auto msg = CreatePointCloud2Msg(points.size(), header, true);
-    FillPointCloud2XYZ(points, *msg);
-    FillPointCloud2Timestamp(timestamps, *msg);
-    return msg;
-}
 }  // namespace kiss_icp_ros::utils


### PR DESCRIPTION
When publishing the point clouds for visualization, for each LiDAR frame, we unnecessarily transform the local map points to the sensor frame to publish it with the same frame as the LiDAR frame. This PR avoids the transformation by directly publishing the local map points in their `frame_id`.

We already discussed this in https://github.com/PRBonn/kiss-icp/pull/285. After https://github.com/PRBonn/kiss-icp/pull/371, in which we added the `odom_lidar` to the tf tree, we can now easily publish the local map at this `frame_id` (assuming that `publish_odom_tf` is set to `true`). If `publish_odom_tf` is `false`, we will now see both the estimated trajectory and the local map because both are published in `odom_lidar`, which is the default fixed frame in rviz.

This is also how we currently do it in Kinematic-ICP.