### PR TITLE
Transform the frame at the beginning of scan

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -35,10 +35,6 @@
 #include <functional>
 #include <vector>
 
-namespace {
-constexpr double mid_pose_stamp{0.5};
-}  // namespace
-
 namespace kiss_icp {
 
 Preprocessor::Preprocessor(const double max_range,
@@ -73,7 +69,7 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
                     for (size_t idx = r.begin(); idx < r.end(); ++idx) {
                         const auto &point = frame.at(idx);
                         const auto &stamp = timestamps.at(idx);
-                        const auto pose = Sophus::SE3d::exp((stamp - mid_pose_stamp) * motion);
+                        const auto pose = Sophus::SE3d::exp(stamp * motion);
                         deskewed_frame.at(idx) = pose * point;
                     };
                 });


### PR DESCRIPTION
Since the beginning of time we decided to deskew the input scans at the middle of the scan duration (*0.5*), the motivation for this was given in #299, and it is an heritage of our initial development based on KITTI (everybody has his dark little secrets). The goal of this PR is to set things (partially) right and deskew at the beginning of the scan (*0.0*), which should be the most common case, at least in the Python setting. 