### PR TITLE
Input timestamps

### DIFF
--- a/python/kiss_icp/preprocess.py
+++ b/python/kiss_icp/preprocess.py
@@ -45,7 +45,7 @@ class Preprocessor:
         return np.asarray(
             self._preprocessor._preprocess(
                 kiss_icp_pybind._Vector3dVector(frame),
-                timestamps,
+                timestamps.ravel(),
                 relative_motion,
             )
         )


### PR DESCRIPTION
The input timestamps to pybind need to be a 1-D array, otherwise a copy is made during the function call. Because we cannot check this statically (thanks python), we decided to go for this (ugly) solution that ensures that the input stamps are always a 1-D view of the input timestamps.