### PR TITLE
Deskewing...again

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -35,10 +35,6 @@
 #include <functional>
 #include <vector>
 
-namespace {
-constexpr double mid_pose_stamp{0.5};
-}  // namespace
-
 namespace kiss_icp {
 
 Preprocessor::Preprocessor(const double max_range,
@@ -63,7 +59,7 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
         if (!deskew_ || timestamps.empty()) {
             return frame;
         } else {
-            const auto motion = relative_motion.log();
+            const auto &motion = relative_motion.log();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
             tbb::parallel_for(
                 // Index Range
@@ -73,7 +69,7 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
                     for (size_t idx = r.begin(); idx < r.end(); ++idx) {
                         const auto &point = frame.at(idx);
                         const auto &stamp = timestamps.at(idx);
-                        const auto pose = Sophus::SE3d::exp((stamp - mid_pose_stamp) * motion);
+                        const auto pose = Sophus::SE3d::exp(-stamp * motion);
                         deskewed_frame.at(idx) = pose * point;
                     };
                 });

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -69,7 +69,8 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
                     for (size_t idx = r.begin(); idx < r.end(); ++idx) {
                         const auto &point = frame.at(idx);
                         const auto &stamp = timestamps.at(idx);
-                        const auto pose = Sophus::SE3d::exp(-stamp * motion);
+                        const auto pose =
+                            relative_motion.inverse() * Sophus::SE3d::exp(stamp * motion);
                         deskewed_frame.at(idx) = pose * point;
                     };
                 });

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -59,7 +59,8 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
         if (!deskew_ || timestamps.empty()) {
             return frame;
         } else {
-            const auto &motion = relative_motion.log();
+            const auto &omega = relative_motion.log();
+            const Sophus::SE3d &inverse_motion = relative_motion.inverse();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
             tbb::parallel_for(
                 // Index Range
@@ -69,8 +70,7 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
                     for (size_t idx = r.begin(); idx < r.end(); ++idx) {
                         const auto &point = frame.at(idx);
                         const auto &stamp = timestamps.at(idx);
-                        const auto pose =
-                            relative_motion.inverse() * Sophus::SE3d::exp(stamp * motion);
+                        const auto pose = inverse_motion * Sophus::SE3d::exp(stamp * omega);
                         deskewed_frame.at(idx) = pose * point;
                     };
                 });


### PR DESCRIPTION
## Motivation
Since the beginning of time we decided to deskew the input scans at the middle of the scan duration (**0.5**), the motivation for this was given in https://github.com/PRBonn/kiss-icp/issues/299, and it is an heritage of our initial development based on KITTI (everybody has his dark little secrets). This PR aim at removing the magic parameter **0.5**, and deskew the scans in more principled way.

## This PR
Our final solution is to first deskew the scans at the beginning of the scan duration. We made this choice as there is no easy way to know if the a scan has been stamped at the beginning or the end of the scan collection, especially from a python perspective. We go for the beginning as this is the most common, and also the "right" way of timestamping. We then transform the resulting point cloud in the local frame of the scan after applying the constant velocity initial guess, basically moving the scan to the end of the predicted motion. This new deskewed frame is than passed to the successive steps of the pipeline. 

## Results

On all tested sequences there is no significant difference between deskeing at **0.5** and the current version, so this can be seen as a style change and a way of having things in the right reference frame. This might be more relevant for low frequency scanners than for typical LiDARS running at 10Hz. 