### PR TITLE
Update GitHub actions' versions

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.apt/cache
           key: ${{ runner.os }}-apt-${{ hashFiles('**/ubuntu_dependencies.yml') }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Move sdist to dist
         run: mkdir -p dist && mv ${{github.workspace}}/python/dist/*.tar.gz dist/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -47,8 +47,9 @@ jobs:
         with:
           package-dir: ${{github.workspace}}/python/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   pypi:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -57,10 +57,11 @@ jobs:
     needs: [cibuildwheel, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: artifact*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
It has been a long time since the GitHub Actions CI for this repo was conceived. Since then, there has been a lot of action in the action space. This PR catches up with these actions upgrading their versions wherever imminent.

## 1.  [actions/cache@v2 to actions/cache@v4](https://github.com/actions/cache/discussions/1510) This one is a simple change!!

![image](https://github.com/user-attachments/assets/be14b2c3-5328-4460-a556-0d000dadc9d5)

## 2. [actions/upload-artifact@v3 to actions/upload-artifact@v4](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) This one has breaking changes!!

![image](https://github.com/user-attachments/assets/bc43e2e4-a04f-4232-a3ce-c4852e5f6f90)

- We now have provide an explicit and unique name to each of the three OS's artifacts. This PR uses the `${{matrix.os}}` variable in the yml file to achieve this uniqueness.
- In the PyPi workflow, we will now have 4 different artifacts generated for each run of the workflow. One for the `*.tar.gz` on ubuntu-latest, and three unique `artifact-${{matrix.os}}` for the three OS's cibuildwheels.

## 3. [actions/download-artifact@v3 to actions/download-artifact@v4](https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md) This one has breaking changes!!

![image](https://github.com/user-attachments/assets/cce10c5c-61cf-4f96-8695-dd9f73cc2433)

- Due to the multiple artifacts being uploaded due to `actions/upload-artifact@v4`, the same has to be propogated to `actions/download-artifact@v4`.
- Instead of just using  `name: artifact` we now use `pattern: artifact*` to download each of the uploaded artifacts with the common pattern `artifact` in their names
- The `merge-multiple: true` flag will still download all these artifacts into the same directory, thereby keeping the publishing to pypi behaviour unaffected. 

## 4.  [actions/setup-python@v3 to actions/setup-python@v4](https://github.com/actions/setup-python/releases/tag/v4.0.0)

- This is mainly for consistency in versions
- `pre-commit.yml` already had the `setup-python@v4`, so upgrading to the same in `python.yml` as well