### PR TITLE
Simplify deskewing

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -60,7 +60,6 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
             return frame;
         } else {
             const auto &omega = relative_motion.log();
-            const Sophus::SE3d &inverse_motion = relative_motion.inverse();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
             tbb::parallel_for(
                 // Index Range
@@ -70,7 +69,7 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
                     for (size_t idx = r.begin(); idx < r.end(); ++idx) {
                         const auto &point = frame.at(idx);
                         const auto &stamp = timestamps.at(idx);
-                        const auto pose = inverse_motion * Sophus::SE3d::exp(stamp * omega);
+                        const auto pose = Sophus::SE3d::exp((stamp - 1.0) * omega);
                         deskewed_frame.at(idx) = pose * point;
                     };
                 });


### PR DESCRIPTION
After the discussion with @niosus in https://github.com/PRBonn/kiss-icp/pull/421, it turned out that we can make the deskewing a bit easier to understand by using the original transformation from the `mid_pose_timestamp` solution, but with a fixed reference timestamp of `1.0`. The motivation behind setting it to `1.0` can be found in the PR reference above.

This is mainly a cosmetic change, but it is more readable because we deskew and represent the scan at the end of the scan duration (in contrast to the current main, where we deskew to the beginning of the scan and then represent it at the end pose).

I checked the first 1000 scans of Riverside01, and we obtain the same results, and it's minimally faster (single thread for proper runtime comparison):

Main:
```shell
────────────────────────── Results for MulranDataset Sequence Riverside01 ──────────────────────────

+---------------------------------+-------+-------+
|                          Metric | Value | Units |
+=================================+=======+=======+
|       Average Translation Error | 3.862 | %     |
|        Average Rotational Error | 0.006 | deg/m |
| Absolute Trajectory Error (ATE) | 5.061 | m     |
| Absolute Rotational Error (ARE) | 0.425 | rad   |
|               Average Frequency |   6   | Hz    |
|                 Average Runtime |  155  | ms    |
+---------------------------------+-------+-------+
```

This PR:

```bash
────────────────────────── Results for MulranDataset Sequence Riverside01 ──────────────────────────
+---------------------------------+-------+-------+
|                          Metric | Value | Units |
+=================================+=======+=======+
|       Average Translation Error | 3.862 | %     |
|        Average Rotational Error | 0.006 | deg/m |
| Absolute Trajectory Error (ATE) | 5.061 | m     |
| Absolute Rotational Error (ARE) | 0.425 | rad   |
|               Average Frequency |   7   | Hz    |
|                 Average Runtime |  143  | ms    |
+---------------------------------+-------+-------+
```
