### PR TITLE
Change default config 

### DIFF
--- a/config/basic.yaml
+++ b/config/basic.yaml
@@ -1,9 +1,9 @@
 out_dir: "results"
 
 data:
-  deskew: False
+  deskew: True
   max_range: 100.0 # can be also changed in the CLI
-  min_range: 5.0
+  min_range: 0.0
 
 mapping:
   max_points_per_voxel: 20

--- a/python/kiss_icp/config/config.py
+++ b/python/kiss_icp/config/config.py
@@ -27,8 +27,8 @@ from pydantic import BaseModel
 
 class DataConfig(BaseModel):
     max_range: float = 100.0
-    min_range: float = 5.0
-    deskew: bool = False
+    min_range: float = 0.0
+    deskew: bool = True
 
 
 class MappingConfig(BaseModel):


### PR DESCRIPTION
**Motivation**

We realize that, by default, `basic.yaml` and `advanced.yaml` have different values for the scan clipping and deskewing. We decided to unify these two configs and enable deskew by default as the only case in which you want to avoid deskewing when timestamps are present is the KITTI dataset (which we agreed we don't care anymore).  