### PR TITLE
Make empty timestamps default everywhere

### DIFF
--- a/python/kiss_icp/datasets/apollo.py
+++ b/python/kiss_icp/datasets/apollo.py
@@ -49,7 +49,7 @@ class ApolloDataset:
         return len(self.scan_files)
 
     def __getitem__(self, idx):
-        return self.get_scan(self.scan_files[idx])
+        return self.get_scan(self.scan_files[idx]), np.array([])
 
     def get_scan(self, scan_file: str):
         points = np.asarray(self.o3d.io.read_point_cloud(scan_file).points, dtype=np.float64)

--- a/python/kiss_icp/datasets/kitti.py
+++ b/python/kiss_icp/datasets/kitti.py
@@ -54,7 +54,7 @@ class KITTIOdometryDataset:
         return len(self.scan_files)
 
     def scans(self, idx):
-        return self.read_point_cloud(self.scan_files[idx])
+        return self.read_point_cloud(self.scan_files[idx]), np.array([])
 
     def apply_calibration(self, poses: np.ndarray) -> np.ndarray:
         """Converts from Velodyne to Camera Frame"""

--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -23,6 +23,8 @@
 import os
 import sys
 
+import numpy as np
+
 
 class McapDataloader:
     def __init__(self, data_dir: str, topic: str, *_, **__):
@@ -58,7 +60,7 @@ class McapDataloader:
     def __getitem__(self, idx):
         msg = next(self.msgs).ros_msg
         self.timestamps.append(self.stamp_to_sec(msg.header.stamp))
-        return self.read_point_cloud(msg)
+        return self.read_point_cloud(msg), np.array([])
 
     def __len__(self):
         return self.n_scans

--- a/python/kiss_icp/datasets/nclt.py
+++ b/python/kiss_icp/datasets/nclt.py
@@ -54,7 +54,9 @@ class NCLTDataset:
         return len(self.scan_files)
 
     def __getitem__(self, idx):
-        return self.read_point_cloud(os.path.join(self.scans_dir, self.scan_files[idx]))
+        return self.read_point_cloud(os.path.join(self.scans_dir, self.scan_files[idx])), np.array(
+            []
+        )
 
     def read_point_cloud(self, file_path: str):
         def _convert(x_s, y_s, z_s):

--- a/python/kiss_icp/datasets/nuscenes.py
+++ b/python/kiss_icp/datasets/nuscenes.py
@@ -76,7 +76,7 @@ class NuScenesDataset:
         return len(self.lidar_tokens)
 
     def __getitem__(self, idx):
-        return self.read_point_cloud(self.lidar_tokens[idx])
+        return self.read_point_cloud(self.lidar_tokens[idx]), np.array([])
 
     def read_point_cloud(self, token: str):
         filename = self.nusc.get("sample_data", token)["filename"]

--- a/python/kiss_icp/datasets/tum.py
+++ b/python/kiss_icp/datasets/tum.py
@@ -93,4 +93,4 @@ class TUMDataset:
                 self.o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault
             ),
         )
-        return np.array(pcd.points, dtype=np.float64)
+        return np.array(pcd.points, dtype=np.float64), np.array([])

--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -98,7 +98,7 @@ class OdometryPipeline:
     # Private interface  ------
     def _run_pipeline(self):
         for idx in get_progress_bar(self._first, self._last):
-            raw_frame, timestamps = self._next(idx)
+            raw_frame, timestamps = self._dataset[idx]
             start_time = time.perf_counter_ns()
             source, keypoints = self.odometry.register_frame(raw_frame, timestamps)
             self.poses[idx - self._first] = self.odometry.last_pose
@@ -113,16 +113,6 @@ class OdometryPipeline:
                 self.odometry.last_pose,
                 self._vis_infos,
             )
-
-    def _next(self, idx):
-        """TODO: re-arrange this logic"""
-        dataframe = self._dataset[idx]
-        try:
-            frame, timestamps = dataframe
-        except ValueError:
-            frame = dataframe
-            timestamps = np.array([])
-        return frame, timestamps
 
     @staticmethod
     def save_poses_kitti_format(filename: str, poses: np.ndarray):

--- a/python/kiss_icp/tools/point_cloud2.py
+++ b/python/kiss_icp/tools/point_cloud2.py
@@ -86,7 +86,7 @@ def read_point_cloud(msg: PointCloud2) -> Tuple[np.ndarray, np.ndarray]:
         max_timestamp = np.max(timestamps)
         timestamps = (timestamps - min_timestamp) / (max_timestamp - min_timestamp)
     else:
-        timestamps = np.ones(points.shape[0])
+        timestamps = np.array([])
     return points.astype(np.float64), timestamps
 
 


### PR DESCRIPTION
Following https://github.com/PRBonn/kiss-icp/pull/428, this PR simplifies the return type of the dataloaders: It is always a tuple of frame with timestamps. In case there are no timestamps, it will be an empty `np.array`.