### PR TITLE
Deskew the scans by default

### DIFF
--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -64,17 +64,11 @@ def _yaml_source(config_file: Optional[Path]) -> Dict[str, Any]:
     return data or {}
 
 
-def load_config(
-    config_file: Optional[Path], deskew: Optional[bool], max_range: Optional[float]
-) -> KISSConfig:
-    """Load configuration from an Optional yaml file. Additionally, deskew and max_range can be
-    also specified from the CLI interface"""
+def load_config(config_file: Optional[Path], max_range: Optional[float]) -> KISSConfig:
 
     config = KISSConfig(**_yaml_source(config_file))
 
     # Override defaults from command line
-    if deskew is not None:
-        config.data.deskew = deskew
     if max_range is not None:
         config.data.max_range = max_range
 

--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -65,7 +65,6 @@ def _yaml_source(config_file: Optional[Path]) -> Dict[str, Any]:
 
 
 def load_config(config_file: Optional[Path], max_range: Optional[float]) -> KISSConfig:
-
     config = KISSConfig(**_yaml_source(config_file))
 
     # Override defaults from command line

--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -43,7 +43,6 @@ class OdometryPipeline:
         self,
         dataset,
         config: Optional[Path] = None,
-        deskew: Optional[bool] = False,
         max_range: Optional[float] = None,
         visualize: bool = False,
         n_scans: int = -1,
@@ -58,7 +57,7 @@ class OdometryPipeline:
         self._last = self._jump + self._n_scans
 
         # Config and output dir
-        self.config = load_config(config, deskew=deskew, max_range=max_range)
+        self.config = load_config(config, max_range=max_range)
         self.results_dir = None
 
         # Pipeline

--- a/python/kiss_icp/tools/cmd.py
+++ b/python/kiss_icp/tools/cmd.py
@@ -226,10 +226,10 @@ def kiss_icp_pipeline(
         jump = 0
     if deskew:
         print(
-            f"[WARNING] The option '--deskew' is deprecated and might be removed in future versions. KISS-ICP now deskew the scans by default."
+            f"[WARNING] The option '--deskew' is deprecated and might be removed in future versions."
         )
         print(
-            f"[WARNING] If you want to change this behaviour create and edit a configuration file using 'kiss_icp_dump_config'. Run then using --config <your_config>."
+            f"[WARNING] KISS-ICP now deskew the scans by default. If you want to change this behaviour create and edit a configuration file using 'kiss_icp_dump_config'. Run then using --config <your_config>."
         )
 
     from kiss_icp.datasets import dataset_factory

--- a/python/kiss_icp/tools/cmd.py
+++ b/python/kiss_icp/tools/cmd.py
@@ -224,8 +224,9 @@ def kiss_icp_pipeline(
     if jump != 0 and dataloader not in jumpable_dataloaders():
         print(f"[WARNING] '{dataloader}' does not support '--jump', starting from first frame")
         jump = 0
+
     print(
-        f"[WARNING] KISS-ICP now deskew the scans by default. If you want to change this behaviour create and edit a configuration file using 'kiss_icp_dump_config'. Run then using --config <your_config>."
+        f"[WARNING] KISS-ICP now deskews the scans by default. If you want to change this behaviour create and edit a configuration file using 'kiss_icp_dump_config'. Then run using --config <your_config>."
     )
     if deskew:
         print(

--- a/python/kiss_icp/tools/cmd.py
+++ b/python/kiss_icp/tools/cmd.py
@@ -224,12 +224,12 @@ def kiss_icp_pipeline(
     if jump != 0 and dataloader not in jumpable_dataloaders():
         print(f"[WARNING] '{dataloader}' does not support '--jump', starting from first frame")
         jump = 0
+    print(
+        f"[WARNING] KISS-ICP now deskew the scans by default. If you want to change this behaviour create and edit a configuration file using 'kiss_icp_dump_config'. Run then using --config <your_config>."
+    )
     if deskew:
         print(
             f"[WARNING] The option '--deskew' is deprecated and might be removed in future versions."
-        )
-        print(
-            f"[WARNING] KISS-ICP now deskew the scans by default. If you want to change this behaviour create and edit a configuration file using 'kiss_icp_dump_config'. Run then using --config <your_config>."
         )
 
     from kiss_icp.datasets import dataset_factory

--- a/python/kiss_icp/tools/cmd.py
+++ b/python/kiss_icp/tools/cmd.py
@@ -155,7 +155,7 @@ def kiss_icp_pipeline(
         is_flag=True,
         help="[Optional] Whether or not to deskew the scan or not",
     ),
-    # Aditional Options ---------------------------------------------------------------------------
+    # Additional Options ---------------------------------------------------------------------------
     visualize: bool = typer.Option(
         False,
         "--visualize",
@@ -224,8 +224,14 @@ def kiss_icp_pipeline(
     if jump != 0 and dataloader not in jumpable_dataloaders():
         print(f"[WARNING] '{dataloader}' does not support '--jump', starting from first frame")
         jump = 0
+    if deskew:
+        print(
+            f"[WARNING] The option '--deskew' is deprecated and might be removed in future versions. KISS-ICP now deskew the scans by default."
+        )
+        print(
+            f"[WARNING] If you want to change this behaviour create and edit a configuration file using 'kiss_icp_dump_config'. Run then using --config <your_config>."
+        )
 
-    # Lazy-loading for faster CLI
     from kiss_icp.datasets import dataset_factory
     from kiss_icp.pipeline import OdometryPipeline
 
@@ -239,7 +245,6 @@ def kiss_icp_pipeline(
             meta=meta,
         ),
         config=config,
-        deskew=deskew,
         max_range=max_range,
         visualize=visualize,
         n_scans=n_scans,


### PR DESCRIPTION
### This PR

Deprecate the `--deskew` option, as now, in the aftermath of #429, we decided to deskew the scans by default. If the `--deskew` is provided we communicate to the user through a warning that we might remove this option in future versions. Furthermore, by default, we advertise to the user that now we deskew the scans by default. This makes sense as, if timestamps are available, there is no reason to don't motion compensate.  If some external pipeline already deskews the scans, the user must provide a custom config where `deskew=False`. This in general should be an exception, as it turns out that constant velocity deskewing is even better than what we used to think 2 years ago. An example on Sejong01:

### No Deskew

![no-deskew](https://github.com/user-attachments/assets/301dac8a-a861-48ba-b4ad-6eb840525594)

### Deskew

![deskew](https://github.com/user-attachments/assets/e83a2416-9337-4bf1-89cb-b306223c467d)

