### PR TITLE
Move the normalization of the timestamps in preprocessing

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -60,11 +60,7 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
             return frame;
         } else {
             const auto &[min, max] = std::minmax_element(timestamps.cbegin(), timestamps.cend());
-            const double &min_time = *min;
-            const double &max_time = *max;
-            const auto normalize = [&](const double t) {
-                return (t - min_time) / (max_time - min_time);
-            };
+            const auto normalize = [&](const double t) { return (t - *min) / (*max - *min); };
             const auto &omega = relative_motion.log();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
             tbb::parallel_for(

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -60,8 +60,10 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
             return frame;
         } else {
             const auto &[min, max] = std::minmax_element(timestamps.cbegin(), timestamps.cend());
-            const auto normalize = [&min, &max](const double t) {
-                return (t - *min) / (*max - *min);
+            const double min_time = *min;
+            const double max_time = *max;
+            const auto normalize = [&](const double t) {
+                return (t - min_time) / (max_time - min_time);
             };
             const auto &omega = relative_motion.log();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -60,7 +60,11 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
             return frame;
         } else {
             const auto &[min, max] = std::minmax_element(timestamps.cbegin(), timestamps.cend());
-            const auto normalize = [&](const double t) { return (t - *min) / (*max - *min); };
+            const double &min_time = *min;
+            const double &max_time = *max;
+            const auto normalize = [&](const double t) {
+                return (t - min_time) / (max_time - min_time);
+            };
             const auto &omega = relative_motion.log();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
             tbb::parallel_for(

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -59,8 +59,8 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
         if (!deskew_ || timestamps.empty()) {
             return frame;
         } else {
-            const auto&[min,max] = std::minmax_element(timestamps.cbegin(),timestamps.cend());
-            const auto normalize = [&](const double t){return (t-*min)/(*max-*min);};
+            const auto &[min, max] = std::minmax_element(timestamps.cbegin(), timestamps.cend());
+            const auto normalize = [&](const double t) { return (t - *min) / (*max - *min); };
             const auto &omega = relative_motion.log();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
             tbb::parallel_for(

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -60,7 +60,9 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
             return frame;
         } else {
             const auto &[min, max] = std::minmax_element(timestamps.cbegin(), timestamps.cend());
-            const auto normalize = [&](const double t) { return (t - *min) / (*max - *min); };
+            const auto normalize = [&min, &max](const double t) {
+                return (t - *min) / (*max - *min);
+            };
             const auto &omega = relative_motion.log();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
             tbb::parallel_for(

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -59,6 +59,8 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
         if (!deskew_ || timestamps.empty()) {
             return frame;
         } else {
+            const auto&[min,max] = std::minmax_element(timestamps.cbegin(),timestamps.cend());
+            const auto normalize = [&](const double t){return (t-*min)/(*max-*min);};
             const auto &omega = relative_motion.log();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
             tbb::parallel_for(
@@ -68,7 +70,7 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
                 [&](const tbb::blocked_range<size_t> &r) {
                     for (size_t idx = r.begin(); idx < r.end(); ++idx) {
                         const auto &point = frame.at(idx);
-                        const auto &stamp = timestamps.at(idx);
+                        const auto &stamp = normalize(timestamps.at(idx));
                         const auto pose = Sophus::SE3d::exp((stamp - 1.0) * omega);
                         deskewed_frame.at(idx) = pose * point;
                     };

--- a/python/kiss_icp/datasets/generic.py
+++ b/python/kiss_icp/datasets/generic.py
@@ -101,7 +101,7 @@ class GenericDataset:
                 def __init__(self, time_field):
                     self.time_field = time_field
                     if self.time_field is None:
-                        self.get_timestamps = lambda pcd: np.array([])
+                        self.get_timestamps = lambda _: np.array([])
                     else:
                         self.get_timestamps = lambda pcd: pcd.point[self.time_field].numpy().ravel()
 

--- a/python/kiss_icp/datasets/generic.py
+++ b/python/kiss_icp/datasets/generic.py
@@ -101,14 +101,9 @@ class GenericDataset:
                 def __init__(self, time_field):
                     self.time_field = time_field
                     if self.time_field is None:
-                        self.get_timestamps = lambda _: np.array([])
+                        self.get_timestamps = lambda pcd: np.array([])
                     else:
-                        self.get_timestamps = lambda pcd: self.min_max_normalize(
-                            pcd.point[self.time_field].numpy().ravel()
-                        )
-
-                def min_max_normalize(self, data):
-                    return (data - np.min(data)) / (np.max(data) - np.min(data))
+                        self.get_timestamps = lambda pcd: pcd.point[self.time_field].numpy().ravel()
 
                 def __call__(self, file):
                     pcd = o3d.t.io.read_point_cloud(file)

--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -60,7 +60,7 @@ class McapDataloader:
     def __getitem__(self, idx):
         msg = next(self.msgs).ros_msg
         self.timestamps.append(self.stamp_to_sec(msg.header.stamp))
-        return self.read_point_cloud(msg), np.array([])
+        return self.read_point_cloud(msg)
 
     def __len__(self):
         return self.n_scans

--- a/python/kiss_icp/tools/point_cloud2.py
+++ b/python/kiss_icp/tools/point_cloud2.py
@@ -81,10 +81,10 @@ def read_point_cloud(msg: PointCloud2) -> Tuple[np.ndarray, np.ndarray]:
     points = points[~np.any(np.isnan(points), axis=1)]
 
     if t_field:
-        timestamps = points_structured[t_field]
+        timestamps = points_structured[t_field].astype(np.float64)
     else:
         timestamps = np.array([])
-    return points.astype(np.float64), timestamps.astype(np.float64)
+    return points.astype(np.float64), timestamps
 
 
 def read_points(

--- a/python/kiss_icp/tools/point_cloud2.py
+++ b/python/kiss_icp/tools/point_cloud2.py
@@ -81,13 +81,10 @@ def read_point_cloud(msg: PointCloud2) -> Tuple[np.ndarray, np.ndarray]:
     points = points[~np.any(np.isnan(points), axis=1)]
 
     if t_field:
-        timestamps = points_structured[t_field].astype(np.float64)
-        min_timestamp = np.min(timestamps)
-        max_timestamp = np.max(timestamps)
-        timestamps = (timestamps - min_timestamp) / (max_timestamp - min_timestamp)
+        timestamps = points_structured[t_field]
     else:
         timestamps = np.array([])
-    return points.astype(np.float64), timestamps
+    return points.astype(np.float64), timestamps.astype(np.float64)
 
 
 def read_points(


### PR DESCRIPTION
### Motivation

The user or a dataloader should not handle timestamp normalization; this should be part of our pipeline. My opinion is that our system should process the data as raw as possible without requiring external manipulations. Furthermore, with this change, we can remove potential sources of errors as the user might not necessarily be aware that timestamps need to be in the range $\[0, 1\]$.

### This PR

Introduction of a timestamp normalization step within the `Preprocessor`. This computation is performed just if `deskew=True` and `timestamps` are not empty. As a result, timestamps normalization is not required anymore in the `generic` and ROS-based dataloaders (`mcap` and `rosbag` through the `tools/point_cloud2.py` file). 