### PR TITLE
Remove max_range and deskew from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ kiss_icp_pipeline --help
 <details>
 <summary>This should print the following help message:</summary>
 
-![out](https://github.com/user-attachments/assets/0991b37d-114b-488a-a6b7-51063c1d9ff3)
+![out](https://github.com/user-attachments/assets/7dea767f-d0e4-4f6b-a523-ba3be25bbfae)
+
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ kiss_icp_pipeline --help
 <details>
 <summary>This should print the following help message:</summary>
 
-![out](https://user-images.githubusercontent.com/21349875/193282970-25a400aa-ebcd-487a-b839-faa04eeca5b9.png)
+![out](https://github.com/user-attachments/assets/b7e0628c-18d1-4359-8dc9-6de783c62b8f)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ kiss_icp_pipeline --help
 
 ![out](https://github.com/user-attachments/assets/7dea767f-d0e4-4f6b-a523-ba3be25bbfae)
 
-
 </details>
 
 For advanced instructions on the Python package please see [this README](python/README.md)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ kiss_icp_pipeline --help
 <details>
 <summary>This should print the following help message:</summary>
 
-![out](https://github.com/user-attachments/assets/b7e0628c-18d1-4359-8dc9-6de783c62b8f)
+![out](https://github.com/user-attachments/assets/0991b37d-114b-488a-a6b7-51063c1d9ff3)
 
 </details>
 

--- a/config/advanced.yaml
+++ b/config/advanced.yaml
@@ -5,7 +5,7 @@ out_dir: "results"
 
 data:
   deskew: True
-  max_range: 100.0 # can be also changed in the CLI
+  max_range: 100.0
   min_range: 0.0
 
 mapping:

--- a/config/basic.yaml
+++ b/config/basic.yaml
@@ -2,7 +2,7 @@ out_dir: "results"
 
 data:
   deskew: True
-  max_range: 100.0 # can be also changed in the CLI
+  max_range: 100.0
   min_range: 0.0
 
 mapping:

--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -64,12 +64,10 @@ def _yaml_source(config_file: Optional[Path]) -> Dict[str, Any]:
     return data or {}
 
 
-def load_config(config_file: Optional[Path], max_range: Optional[float]) -> KISSConfig:
-    config = KISSConfig(**_yaml_source(config_file))
+def load_config(config_file: Optional[Path]) -> KISSConfig:
+    """Load configuration from an Optional yaml file."""
 
-    # Override defaults from command line
-    if max_range is not None:
-        config.data.max_range = max_range
+    config = KISSConfig(**_yaml_source(config_file))
 
     # Check if there is a possible mistake
     if config.data.max_range < config.data.min_range:

--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -65,7 +65,8 @@ def _yaml_source(config_file: Optional[Path]) -> Dict[str, Any]:
 
 
 def load_config(config_file: Optional[Path]) -> KISSConfig:
-    """Load configuration from an Optional yaml file."""
+    """Load configuration from an optional yaml file."""
+
 
     config = KISSConfig(**_yaml_source(config_file))
 

--- a/python/kiss_icp/config/parser.py
+++ b/python/kiss_icp/config/parser.py
@@ -67,7 +67,6 @@ def _yaml_source(config_file: Optional[Path]) -> Dict[str, Any]:
 def load_config(config_file: Optional[Path]) -> KISSConfig:
     """Load configuration from an optional yaml file."""
 
-
     config = KISSConfig(**_yaml_source(config_file))
 
     # Check if there is a possible mistake

--- a/python/kiss_icp/pipeline.py
+++ b/python/kiss_icp/pipeline.py
@@ -43,7 +43,6 @@ class OdometryPipeline:
         self,
         dataset,
         config: Optional[Path] = None,
-        max_range: Optional[float] = None,
         visualize: bool = False,
         n_scans: int = -1,
         jump: int = 0,
@@ -57,7 +56,7 @@ class OdometryPipeline:
         self._last = self._jump + self._n_scans
 
         # Config and output dir
-        self.config = load_config(config, max_range=max_range)
+        self.config = load_config(config)
         self.results_dir = None
 
         # Pipeline

--- a/python/kiss_icp/tools/cmd.py
+++ b/python/kiss_icp/tools/cmd.py
@@ -142,12 +142,6 @@ def kiss_icp_pipeline(
         show_default=False,
         help="[Optional] Path to the configuration file",
     ),
-    max_range: Optional[float] = typer.Option(
-        None,
-        "--max_range",
-        show_default=False,
-        help="[Optional] Overrides the max_range from the default configuration",
-    ),
     deskew: bool = typer.Option(
         None,
         "--deskew",

--- a/python/kiss_icp/tools/cmd.py
+++ b/python/kiss_icp/tools/cmd.py
@@ -240,7 +240,6 @@ def kiss_icp_pipeline(
             meta=meta,
         ),
         config=config,
-        max_range=max_range,
         visualize=visualize,
         n_scans=n_scans,
         jump=jump,

--- a/python/kiss_icp/tools/cmd.py
+++ b/python/kiss_icp/tools/cmd.py
@@ -142,13 +142,6 @@ def kiss_icp_pipeline(
         show_default=False,
         help="[Optional] Path to the configuration file",
     ),
-    deskew: bool = typer.Option(
-        None,
-        "--deskew",
-        show_default=False,
-        is_flag=True,
-        help="[Optional] Whether or not to deskew the scan or not",
-    ),
     # Additional Options ---------------------------------------------------------------------------
     visualize: bool = typer.Option(
         False,
@@ -218,14 +211,6 @@ def kiss_icp_pipeline(
     if jump != 0 and dataloader not in jumpable_dataloaders():
         print(f"[WARNING] '{dataloader}' does not support '--jump', starting from first frame")
         jump = 0
-
-    print(
-        f"[WARNING] KISS-ICP now deskews the scans by default. If you want to change this behaviour create and edit a configuration file using 'kiss_icp_dump_config'. Then run using --config <your_config>."
-    )
-    if deskew:
-        print(
-            f"[WARNING] The option '--deskew' is deprecated and might be removed in future versions."
-        )
 
     from kiss_icp.datasets import dataset_factory
     from kiss_icp.pipeline import OdometryPipeline


### PR DESCRIPTION
After deprecating the `--deskew` option from the CLI in https://github.com/PRBonn/kiss-icp/pull/432, I think it's time to remove the `--max_range` option too. I don't know how widely this was used (at least I didn't), but it's much cleaner without it because now the CLI options are pipeline-specific and do not overwrite the configuration of KISS-ICP.

However, I would like to keep this as a draft (for now) and see if anyone has objections. If so, please comment here :)
