### PR TITLE
Remove divided by three in the robust kernel

### DIFF
--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -51,7 +51,7 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
                                                          local_map_,     // voxel_map
                                                          initial_guess,  // initial_guess
                                                          3.0 * sigma,    // max_correspondence_dist
-                                                         sigma / 3.0);   // kernel
+                                                         sigma);         // kernel
 
     // Compute the difference between the prediction and the actual estimate
     const auto model_deviation = initial_guess.inverse() * new_pose;

--- a/python/kiss_icp/kiss_icp.py
+++ b/python/kiss_icp/kiss_icp.py
@@ -59,7 +59,7 @@ class KissICP:
             voxel_map=self.local_map,
             initial_guess=initial_guess,
             max_correspondance_distance=3 * sigma,
-            kernel=sigma / 3,
+            kernel=sigma,
         )
 
         # Compute the difference between the prediction and the actual estimate


### PR DESCRIPTION
# Motivation
@benemer notice that, in some specific scenarios, our current optimization scheme rejects all the points in the scan, resulting in a situation where the estimate gets stacked in a _no motion_ local minimum. One example of this behavior is represented in the Apollo Dataset, sequence MathildaAVE, where this affect the overall length of the trajectory:

![image](https://github.com/user-attachments/assets/78b6f495-ff73-474d-a0dc-63850c7c0cca)


# This PR

While our initial dream for this PR will be to wipe out the robust kernel (finally) altogether, we realize that by simply enlarging the `kernel_scale` parameter, we can obtain performances that are slightly better than the current `main` or even the "pre-cyrill" thresholding scheme. 

# Results

As shown in the images below, the results are similar overall for all three settings (main, "pre-Cyrill," and this PR), with this PR having a slight edge on some sequences. Furthermore, on Mathilda AVE:

![image](https://github.com/user-attachments/assets/79fc767a-7fe2-4080-98ba-c496ade6ca40)


In the name of data-driven analysis, which always guided this project,  we decided that the kernel can live another day; although it doesn't make us happy,


### Main

![image](https://github.com/user-attachments/assets/91c90f5a-a336-4758-ab9a-f06ee027dfbc)

### "Pre-Cyrill" Optimization

![image](https://github.com/user-attachments/assets/b58d0a76-caaa-4973-9b89-8e7fc78c8556)


###  This PR

![image](https://github.com/user-attachments/assets/117fe1f8-a2ca-4bc6-b141-56ffe788df2f)



