### PR TITLE
Fix open3d not raising an exception on invalid files when guessing dataset format

### DIFF
--- a/python/kiss_icp/datasets/generic.py
+++ b/python/kiss_icp/datasets/generic.py
@@ -86,6 +86,10 @@ class GenericDataset:
             import open3d as o3d
 
             try_pcd = o3d.t.io.read_point_cloud(first_scan_file)
+            if try_pcd.is_empty():
+                #open3d binding does not raise an exception if file is unreadable or extension is not supported
+                raise Exception("Cloud is empty")
+            
             stamps_keys = ["t", "timestamp", "timestamps", "time", "stamps"]
             stamp_field = None
             for key in stamps_keys:

--- a/python/kiss_icp/datasets/generic.py
+++ b/python/kiss_icp/datasets/generic.py
@@ -87,9 +87,9 @@ class GenericDataset:
 
             try_pcd = o3d.t.io.read_point_cloud(first_scan_file)
             if try_pcd.is_empty():
-                #open3d binding does not raise an exception if file is unreadable or extension is not supported
+                # open3d binding does not raise an exception if file is unreadable or extension is not supported
                 raise Exception("Cloud is empty")
-            
+
             stamps_keys = ["t", "timestamp", "timestamps", "time", "stamps"]
             stamp_field = None
             for key in stamps_keys:

--- a/python/kiss_icp/datasets/generic.py
+++ b/python/kiss_icp/datasets/generic.py
@@ -88,7 +88,7 @@ class GenericDataset:
             try_pcd = o3d.t.io.read_point_cloud(first_scan_file)
             if try_pcd.is_empty():
                 # open3d binding does not raise an exception if file is unreadable or extension is not supported
-                raise Exception("Cloud is empty")
+                raise Exception("Generic Dataloader| Open3d PointCloud file is empty")
 
             stamps_keys = ["t", "timestamp", "timestamps", "time", "stamps"]
             stamp_field = None


### PR DESCRIPTION
If the file is unreadable the code doesn't continue to read cloud with other available libraries