### PR TITLE
Gupta/fix serialized dataloaders

### DIFF
--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -76,6 +76,7 @@ class McapDataloader:
         )
 
     def reset(self):
+        self.timestamps = []
         self.bag = self.make_reader(open(self.mcap_file, "rb"))
         self.msgs = self.read_ros2_messages(self.mcap_file, topics=[self.topic])
 

--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -42,15 +42,18 @@ class McapDataloader:
         # we expect `data_dir` param to be a path to the .mcap file, so rename for clarity
         assert os.path.isfile(data_dir), "mcap dataloader expects an existing MCAP file"
         self.sequence_id = os.path.basename(data_dir).split(".")[0]
-        mcap_file = str(data_dir)
+        self.mcap_file = str(data_dir)
 
-        self.bag = make_reader(open(mcap_file, "rb"))
+        self.make_reader = make_reader
+        self.read_ros2_messages = read_ros2_messages
+        self.read_point_cloud = read_point_cloud
+
+        self.bag = self.make_reader(open(self.mcap_file, "rb"))
         self.summary = self.bag.get_summary()
         self.topic = self.check_topic(topic)
         self.n_scans = self._get_n_scans()
-        self.msgs = read_ros2_messages(mcap_file, topics=[self.topic])
+        self.msgs = self.read_ros2_messages(self.mcap_file, topics=[self.topic])
         self.timestamps = []
-        self.read_point_cloud = read_point_cloud
         self.use_global_visualizer = True
 
     def __del__(self):
@@ -71,6 +74,10 @@ class McapDataloader:
             for (id, count) in self.summary.statistics.channel_message_counts.items()
             if self.summary.channels[id].topic == self.topic
         )
+
+    def reset(self):
+        self.bag = self.make_reader(open(self.mcap_file, "rb"))
+        self.msgs = self.read_ros2_messages(self.mcap_file, topics=[self.topic])
 
     @staticmethod
     def stamp_to_sec(stamp):

--- a/python/kiss_icp/datasets/rosbag.py
+++ b/python/kiss_icp/datasets/rosbag.py
@@ -68,8 +68,8 @@ class RosbagDataset:
         self.n_scans = self.bag.topics[self.topic].msgcount
 
         # limit connections to selected topic
-        connections = [x for x in self.bag.connections if x.topic == self.topic]
-        self.msgs = self.bag.messages(connections=connections)
+        self.connections = [x for x in self.bag.connections if x.topic == self.topic]
+        self.msgs = self.bag.messages(connections=self.connections)
         self.timestamps = []
 
         # Visualization Options
@@ -87,6 +87,11 @@ class RosbagDataset:
         self.timestamps.append(self.to_sec(timestamp))
         msg = self.bag.deserialize(rawdata, connection.msgtype)
         return self.read_point_cloud(msg)
+
+    def reset(self):
+        self.bag.close()
+        self.bag.open()
+        self.msgs = self.bag.messages(connections=self.connections)
 
     @staticmethod
     def to_sec(nsec: int):

--- a/python/kiss_icp/datasets/rosbag.py
+++ b/python/kiss_icp/datasets/rosbag.py
@@ -89,6 +89,7 @@ class RosbagDataset:
         return self.read_point_cloud(msg)
 
     def reset(self):
+        self.timestamps = []
         self.bag.close()
         self.bag.open()
         self.msgs = self.bag.messages(connections=self.connections)


### PR DESCRIPTION
#### This PR adds a reset method for serialized dataloaders, namely **rosbag** and **mcap**
- This is useful when we need to go through the dataset again in the same pipeline
- For example during a global mapping run at the end of the pipeline
- The other dataloaders are indexed and therefore allow directly using index `0` for starting over, but rosbags cannot do that