### PR TITLE
Fix tf frame calculation when base_frame is given

### DIFF
--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -156,7 +156,7 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
     const auto pose = [&]() -> Sophus::SE3d {
         if (egocentric_estimation) return kiss_pose;
         const Sophus::SE3d cloud2base = LookupTransform(base_frame_, cloud_frame_id, tf2_buffer_);
-        return cloud2base * kiss_pose * cloud2base.inverse();
+        return kiss_pose * cloud2base.inverse();
     }();
 
     // Broadcast the tf ---


### PR DESCRIPTION
There seems to be an error in TF frame calculation when base_frame is given.

Running current code with base-lidar frame transformation:
```
ros2 run tf2_ros static_transform_publisher --x 0 --y 0 --z 10 --roll 0 --pitch 0 --yaw 0 --frame-id base_link --child-frame-id os_lidar
```
gives following result:

![image](https://github.com/user-attachments/assets/5f2e3922-2725-4a58-a622-81e6f4550403)

After proposed change it gives following result:
![image](https://github.com/user-attachments/assets/26f76eaa-5beb-4abd-bef3-50ff13aa6f43)
