### PR TITLE
Adding twist information and static covariances into odometry message

### DIFF
--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -46,6 +46,8 @@ find_package(rclcpp_components REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 
 # ROS 2 node
@@ -62,6 +64,8 @@ ament_target_dependencies(
   rcutils
   sensor_msgs
   std_msgs
+  tf2
+  tf2_geometry_msgs
   tf2_ros)
 
 rclcpp_components_register_node(odometry_component PLUGIN "kiss_icp_ros::OdometryServer" EXECUTABLE kiss_icp_node)

--- a/ros/package.xml
+++ b/ros/package.xml
@@ -39,6 +39,8 @@
   <depend>rcutils</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
 
   <depend>eigen</depend>

--- a/ros/src/OdometryServer.hpp
+++ b/ros/src/OdometryServer.hpp
@@ -34,7 +34,9 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <string>
+#include <optional>
 
 namespace kiss_icp_ros {
 
@@ -77,6 +79,9 @@ private:
     /// KISS-ICP
     std::unique_ptr<kiss_icp::pipeline::KissICP> kiss_icp_;
 
+    /// State History.
+    std::optional<nav_msgs::msg::Odometry> last_odom_msg_;
+
     /// Global/map coordinate frame.
     std::string lidar_odom_frame_{"odom_lidar"};
     std::string base_frame_{};
@@ -84,6 +89,8 @@ private:
     /// Covariance diagonal
     double position_covariance_;
     double orientation_covariance_;
+    double linear_velocity_covariance_;
+    double angular_velocity_covariance_;
 };
 
 }  // namespace kiss_icp_ros


### PR DESCRIPTION
Adds Twist components in Odometry Message. 

I am having trouble validating this change thus far, so we can consider this PR a draft while I can prove that this works. 