### PR TITLE
Enforce click < 8.2

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "pyquaternion",
     "rich",
     "tqdm",
+    "click<=8.1",
     "typer[all]>=0.6.0",
 ]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pyquaternion",
     "rich",
     "tqdm",
-    "click<=8.1",
+    "click<=8.1", # TODO: Remove
     "typer[all]>=0.6.0",
 ]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pyquaternion",
     "rich",
     "tqdm",
-    "click<=8.1", # TODO: Remove
+    "click<8.2", # TODO: Remove
     "typer[all]>=0.6.0",
 ]
 


### PR DESCRIPTION
The CI failed on KISS-SLAM, because `typer` depends on `click` for which version 8.2 got released two days ago. This version has some changes that break `typer`, see https://github.com/fastapi/typer/pull/1145.

For now I explicitly added `click` as dependency and restricted the version. As soon as https://github.com/fastapi/typer/pull/1145 is merged, we can remove it again and rely on `typer` handling it.