### PR TITLE
Make KISS-ICP compatible with Polyscope 2.4.0

### DIFF
--- a/python/kiss_icp/tools/visualizer.py
+++ b/python/kiss_icp/tools/visualizer.py
@@ -268,12 +268,12 @@ class Kissualizer(StubVisualizer):
 
     def _trajectory_pick_callback(self):
         if self._gui.GetIO().MouseClicked[0]:
-            pick_selection = self._ps.get_selection()
             name = ""
             idx = 0
-            try:
+            pick_selection = self._ps.get_selection()
+            try:  # Compatile with old polyscope versions
                 name, idx = pick_selection
-            except TypeError:
+            except TypeError:  # Compatible with polyscope >= 2.4.0
                 if pick_selection.is_hit:
                     name = pick_selection.structure_name
                     idx = pick_selection.structure_data["index"]

--- a/python/kiss_icp/tools/visualizer.py
+++ b/python/kiss_icp/tools/visualizer.py
@@ -268,14 +268,10 @@ class Kissualizer(StubVisualizer):
 
     def _trajectory_pick_callback(self):
         if self._gui.GetIO().MouseClicked[0]:
-            name = ""
-            idx = 0
             pick_selection = self._ps.get_selection()
-            if pick_selection.is_hit:
-                name = pick_selection.structure_name
-                idx = pick_selection.structure_data["index"]
+            name = pick_selection.structure_name
             if name == "trajectory" and self._ps.has_point_cloud(name):
-                pose = self._trajectory[idx]
+                pose = self._trajectory[pick_selection.structure_data["index"]]
                 self._selected_pose = f"x: {pose[0]:7.3f}, y: {pose[1]:7.3f}, z: {pose[2]:7.3f}>"
             else:
                 self._selected_pose = ""

--- a/python/kiss_icp/tools/visualizer.py
+++ b/python/kiss_icp/tools/visualizer.py
@@ -268,7 +268,15 @@ class Kissualizer(StubVisualizer):
 
     def _trajectory_pick_callback(self):
         if self._gui.GetIO().MouseClicked[0]:
-            name, idx = self._ps.get_selection()
+            pick_selection = self._ps.get_selection()
+            name = ""
+            idx = 0
+            try:
+                name, idx = pick_selection
+            except TypeError:
+                if pick_selection.is_hit:
+                    name = pick_selection.structure_name
+                    idx = pick_selection.structure_data["index"]
             if name == "trajectory" and self._ps.has_point_cloud(name):
                 pose = self._trajectory[idx]
                 self._selected_pose = f"x: {pose[0]:7.3f}, y: {pose[1]:7.3f}, z: {pose[2]:7.3f}>"

--- a/python/kiss_icp/tools/visualizer.py
+++ b/python/kiss_icp/tools/visualizer.py
@@ -271,12 +271,9 @@ class Kissualizer(StubVisualizer):
             name = ""
             idx = 0
             pick_selection = self._ps.get_selection()
-            try:  # Compatile with old polyscope versions
-                name, idx = pick_selection
-            except TypeError:  # Compatible with polyscope >= 2.4.0
-                if pick_selection.is_hit:
-                    name = pick_selection.structure_name
-                    idx = pick_selection.structure_data["index"]
+            if pick_selection.is_hit:
+                name = pick_selection.structure_name
+                idx = pick_selection.structure_data["index"]
             if name == "trajectory" and self._ps.has_point_cloud(name):
                 pose = self._trajectory[idx]
                 self._selected_pose = f"x: {pose[0]:7.3f}, y: {pose[1]:7.3f}, z: {pose[2]:7.3f}>"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 [project.optional-dependencies]
 all = [
     "open3d>=0.16",
-    "polyscope>=2.2.1",
+    "polyscope>=2.4.0",
     "ouster-sdk>=0.11",
     "pyntcloud",
     "PyYAML",


### PR DESCRIPTION
Like pointed out in the issue #468 , polyscope 2.4.0 changed the result of the method "get_selection()". I propose a solution that is compatible with both the previous versions and the new one, even if a bit ugly.
@saurabh1002 what do you think?