### PR TITLE
Update visualizer callback to fit for PolyScope API changes

### DIFF
--- a/python/kiss_icp/tools/visualizer.py
+++ b/python/kiss_icp/tools/visualizer.py
@@ -268,7 +268,9 @@ class Kissualizer(StubVisualizer):
 
     def _trajectory_pick_callback(self):
         if self._gui.GetIO().MouseClicked[0]:
-            name, idx = self._ps.get_selection()
+            selection = self._ps.get_selection()
+            name = selection.structure_name
+            idx = selection.local_index
             if name == "trajectory" and self._ps.has_point_cloud(name):
                 pose = self._trajectory[idx]
                 self._selected_pose = f"x: {pose[0]:7.3f}, y: {pose[1]:7.3f}, z: {pose[2]:7.3f}>"


### PR DESCRIPTION
In `PolyScope v2.4.0`, structure `PickResult` has changed (possibly extended, but I failed to find a historical documentation), thus we cannot treat it as a tuple and unpack it, or there will be a TypeError.

See [this doc](https://polyscope.run/py/basics/interactive_UIs_and_animation/#picking-selection-and-querying-the-scene) for details.

Maybe some version ascertainment is required.