### PR TITLE
pass by reference the pointclouds

### DIFF
--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -191,8 +191,8 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
     odom_publisher_->publish(std::move(odom_msg));
 }
 
-void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> frame,
-                                   const std::vector<Eigen::Vector3d> keypoints,
+void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> &frame,
+                                   const std::vector<Eigen::Vector3d> &keypoints,
                                    const std_msgs::msg::Header &header) {
     const auto kiss_map = kiss_icp_->LocalMap();
     const auto kiss_pose = kiss_icp_->pose().inverse();

--- a/ros/src/OdometryServer.hpp
+++ b/ros/src/OdometryServer.hpp
@@ -52,8 +52,8 @@ private:
     void PublishOdometry(const Sophus::SE3d &kiss_pose, const std_msgs::msg::Header &header);
 
     /// Stream the debugging point clouds for visualization (if required)
-    void PublishClouds(const std::vector<Eigen::Vector3d> frame,
-                       const std::vector<Eigen::Vector3d> keypoints,
+    void PublishClouds(const std::vector<Eigen::Vector3d> &frame,
+                       const std::vector<Eigen::Vector3d> &keypoints,
                        const std_msgs::msg::Header &header);
 
 private:


### PR DESCRIPTION
The `OdometryServer::PublishClouds` function was passing the point clouds by value. This PR addresses the issue by passing it as a reference.