### PR TITLE
Added adaptive covariance to odometry messages

### DIFF
--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -166,4 +166,52 @@ Sophus::SE3d Registration::AlignPointsToMap(const std::vector<Eigen::Vector3d> &
     return T_icp * initial_guess;
 }
 
+RegistrationResult Registration::AlignPointsToMapWithMetrics(
+                                    const std::vector<Eigen::Vector3d> &frame,
+                                    const VoxelHashMap &voxel_map,
+                                    const Sophus::SE3d &initial_guess,
+                                    const double max_distance,
+                                    const double kernel_scale) {
+    RegistrationResult result;
+    result.num_source_points = frame.size();
+    result.num_correspondences = 0;
+    
+    if (voxel_map.Empty()) {
+        result.pose = initial_guess;
+        return result;
+    }
+
+    // Equation (9)
+    std::vector<Eigen::Vector3d> source = frame;
+    TransformPoints(initial_guess, source);
+
+    // ICP-loop
+    Sophus::SE3d T_icp = Sophus::SE3d();
+    size_t last_correspondence_count = 0;
+    
+    for (int j = 0; j < max_num_iterations_; ++j) {
+        // Equation (10)
+        const auto correspondences = DataAssociation(source, voxel_map, max_distance);
+        last_correspondence_count = correspondences.size();  // Track correspondence count
+        
+        // Equation (11)
+        const auto &[JTJ, JTr] = BuildLinearSystem(correspondences, kernel_scale);
+        const Eigen::Vector6d dx = JTJ.ldlt().solve(-JTr);
+        const Sophus::SE3d estimation = Sophus::SE3d::exp(dx);
+        
+        // Equation (12)
+        TransformPoints(estimation, source);
+        
+        // Update iterations
+        T_icp = estimation * T_icp;
+        
+        // Termination criteria
+        if (dx.norm() < convergence_criterion_) break;
+    }
+    
+    result.pose = T_icp * initial_guess;
+    result.num_correspondences = last_correspondence_count;  // Store final correspondence count
+    return result;
+}
+
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Registration.hpp
+++ b/cpp/kiss_icp/core/Registration.hpp
@@ -30,10 +30,25 @@
 
 namespace kiss_icp {
 
+// Struct to hold registration results with quality metrics
+struct RegistrationResult {
+    Sophus::SE3d pose;
+    size_t num_correspondences;
+    size_t num_source_points;
+};
+
 struct Registration {
     explicit Registration(int max_num_iteration, double convergence_criterion, int max_num_threads);
 
     Sophus::SE3d AlignPointsToMap(const std::vector<Eigen::Vector3d> &frame,
+                                  const VoxelHashMap &voxel_map,
+                                  const Sophus::SE3d &initial_guess,
+                                  const double max_correspondence_distance,
+                                  const double kernel_scale);
+
+    // Method that returns registration metrics for adaptive covariance
+    RegistrationResult AlignPointsToMapWithMetrics(
+                                  const std::vector<Eigen::Vector3d> &frame,
                                   const VoxelHashMap &voxel_map,
                                   const Sophus::SE3d &initial_guess,
                                   const double max_correspondence_distance,

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -46,12 +46,35 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
     // Compute initial_guess for ICP
     const auto initial_guess = last_pose_ * last_delta_;
 
-    // Run ICP
-    const auto new_pose = registration_.AlignPointsToMap(source,         // frame
+    // Conditional execution based on metrics toggle
+    Sophus::SE3d new_pose;
+    
+    if (use_registration_metrics_) {
+        // NEW PATH: Use metrics-enabled method
+        const auto result = registration_.AlignPointsToMapWithMetrics(
+                                                         source,         // frame
                                                          local_map_,     // voxel_map
                                                          initial_guess,  // initial_guess
                                                          3.0 * sigma,    // max_correspondence_dist
                                                          sigma);         // kernel
+        
+        new_pose = result.pose;
+        
+        // Store registration quality metrics
+        last_num_correspondences_ = result.num_correspondences;
+        last_num_source_points_ = result.num_source_points;
+    } else {
+        // OLD PATH: Use original method (backward compatible)
+        new_pose = registration_.AlignPointsToMap(source,         // frame
+                                                  local_map_,     // voxel_map
+                                                  initial_guess,  // initial_guess
+                                                  3.0 * sigma,    // max_correspondence_dist
+                                                  sigma);         // kernel
+        
+        // Reset metrics to zero when not using metrics path
+        last_num_correspondences_ = 0;
+        last_num_source_points_ = 0;
+    }
 
     // Compute the difference between the prediction and the actual estimate
     const auto model_deviation = initial_guess.inverse() * new_pose;

--- a/cpp/kiss_icp/pipeline/KissICP.hpp
+++ b/cpp/kiss_icp/pipeline/KissICP.hpp
@@ -84,9 +84,24 @@ public:
     Sophus::SE3d &delta() { return last_delta_; }
     void Reset();
 
+    // Get registration quality metrics (for adaptive covariance)
+    size_t num_correspondences() const { return last_num_correspondences_; }
+    size_t num_source_points() const { return last_num_source_points_; }
+    
+    // Setter/getter to enable/disable metrics collection
+    void setUseRegistrationMetrics(bool enable) { use_registration_metrics_ = enable; }
+    bool useRegistrationMetrics() const { return use_registration_metrics_; }
+
 private:
     Sophus::SE3d last_pose_;
     Sophus::SE3d last_delta_;
+    
+    // Registration quality metrics
+    size_t last_num_correspondences_ = 0;
+    size_t last_num_source_points_ = 0;
+    
+    // Toggle for metrics collection (default: OFF for backward compatibility)
+    bool use_registration_metrics_ = false;
 
     // KISS-ICP pipeline modules
     KISSConfig config_;

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 cmake_minimum_required(VERSION 3.16...3.26)
-project(kiss_icp VERSION 1.2.3 LANGUAGES CXX)
+project(kiss_icp VERSION 1.2.3 LANGUAGES C CXX)
 
 set(CMAKE_BUILD_TYPE Release)
 
@@ -39,6 +39,7 @@ else()
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -48,6 +49,12 @@ find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(std_srvs REQUIRED)
+
+# Generate custom messages
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/RegistrationMetrics.msg"
+  DEPENDENCIES std_msgs
+)
 
 # ROS 2 node
 add_library(odometry_component SHARED src/OdometryServer.cpp)
@@ -65,6 +72,10 @@ ament_target_dependencies(
   std_msgs
   std_srvs
   tf2_ros)
+
+# Link against the generated messages
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(odometry_component "${cpp_typesupport_target}")
 
 rclcpp_components_register_node(odometry_component PLUGIN "kiss_icp_ros::OdometryServer" EXECUTABLE kiss_icp_node)
 

--- a/ros/config/config.yaml
+++ b/ros/config/config.yaml
@@ -13,6 +13,18 @@ kiss_icp_node:
     # position_covariance: 0.1
     # orientation_covariance: 0.1
 
+    ####    Adaptive Covariance Parameters    ####
+    # Set enable: true to activate adaptive covariance based on registration quality
+    # Set metrics_only_mode: true to collect metrics but publish fixed covariance (for calibration)
+    adaptive_covariance:
+      enable: false  # DEFAULT: DISABLED (backward compatible)
+      metrics_only_mode: false  # Collect metrics but use fixed covariance (for finding nominal_keypoints)
+      nominal_keypoints: 1000.0    # Expected keypoints in feature-rich environment
+      min_ratio: 0.5               # Start increasing covariance below 50% of nominal
+      max_multiplier: 10.0         # Maximum 10x covariance inflation
+      enable_smoothing: true       # Smooth covariance changes over time
+      smoothing_alpha: 0.3         # Higher = less smoothing (0.0-1.0)
+
     ####    Core KISS-ICP parameters    ####
 
     data:

--- a/ros/msg/RegistrationMetrics.msg
+++ b/ros/msg/RegistrationMetrics.msg
@@ -1,0 +1,6 @@
+# Registration quality metrics for adaptive covariance
+# This message contains metrics from KISS-ICP registration
+
+uint64 num_correspondences    # Number of point correspondences found in ICP
+uint64 num_source_points      # Number of source points used for registration
+

--- a/ros/package.xml
+++ b/ros/package.xml
@@ -33,8 +33,12 @@
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
 
   <depend>geometry_msgs</depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
@@ -50,6 +54,8 @@
   <depend>robin-map-dev</depend>
 
   <exec_depend>ros2launch</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #include <Eigen/Core>
+#include <algorithm>
 #include <memory>
 #include <sophus/se3.hpp>
 #include <utility>
@@ -78,7 +79,27 @@ OdometryServer::OdometryServer(const rclcpp::NodeOptions &options)
 
     // Construct the main KISS-ICP odometry node
     kiss_icp_ = std::make_unique<kiss_icp::pipeline::KissICP>(config);
+    
+    // Enable metrics collection if adaptive covariance is enabled OR metrics_only_mode is enabled
+    // (use_adaptive_covariance_ and metrics_only_mode_ were set in initializeParameters)
+    kiss_icp_->setUseRegistrationMetrics(use_adaptive_covariance_ || metrics_only_mode_);
+    
+    if (metrics_only_mode_) {
+        RCLCPP_INFO(get_logger(), "Registration metrics collection ENABLED (metrics-only mode - fixed covariance)");
+    } else if (use_adaptive_covariance_) {
+        RCLCPP_INFO(get_logger(), "Registration metrics collection ENABLED (adaptive covariance)");
+    } else {
+        RCLCPP_INFO(get_logger(), "Registration metrics collection DISABLED (using original method)");
+    }
+    
+    // Initialize metrics publisher if metrics collection is enabled
+    if (use_adaptive_covariance_ || metrics_only_mode_) {
+        rclcpp::QoS metrics_qos((rclcpp::SystemDefaultsQoS().keep_last(10).durability_volatile()));
+        metrics_pub_ = create_publisher<kiss_icp::msg::RegistrationMetrics>("kiss/metrics", metrics_qos);
+        RCLCPP_INFO(get_logger(), "Metrics publisher initialized: /kiss/metrics");
+    }
 
+    process_each_x_frame_ = declare_parameter<int>("process_each_x_frame", 1);
     // Initialize subscribers
     pointcloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
         "pointcloud_topic", rclcpp::SensorDataQoS(),
@@ -123,6 +144,31 @@ void OdometryServer::initializeParameters(kiss_icp::pipeline::KISSConfig &config
     RCLCPP_INFO(this->get_logger(), "\tPosition covariance: %.2f", position_covariance_);
     orientation_covariance_ = declare_parameter<double>("orientation_covariance", 0.1);
     RCLCPP_INFO(this->get_logger(), "\tOrientation covariance: %.2f", orientation_covariance_);
+    
+    // Adaptive covariance parameters
+    use_adaptive_covariance_ = declare_parameter<bool>("adaptive_covariance.enable", false);
+    RCLCPP_INFO(this->get_logger(), "\tUse adaptive covariance: %d", use_adaptive_covariance_);
+    
+    metrics_only_mode_ = declare_parameter<bool>("adaptive_covariance.metrics_only_mode", false);
+    RCLCPP_INFO(this->get_logger(), "\tMetrics only mode: %d", metrics_only_mode_);
+    
+    // Only read other adaptive params if enabled or metrics_only_mode
+    if (use_adaptive_covariance_ || metrics_only_mode_) {
+        nominal_keypoint_count_ = declare_parameter<double>("adaptive_covariance.nominal_keypoints", 1000.0);
+        RCLCPP_INFO(this->get_logger(), "\tNominal keypoint count: %.0f", nominal_keypoint_count_);
+        
+        min_keypoint_ratio_ = declare_parameter<double>("adaptive_covariance.min_ratio", 0.5);
+        RCLCPP_INFO(this->get_logger(), "\tMin keypoint ratio: %.2f", min_keypoint_ratio_);
+        
+        max_covariance_multiplier_ = declare_parameter<double>("adaptive_covariance.max_multiplier", 10.0);
+        RCLCPP_INFO(this->get_logger(), "\tMax covariance multiplier: %.1fx", max_covariance_multiplier_);
+        
+        enable_covariance_smoothing_ = declare_parameter<bool>("adaptive_covariance.enable_smoothing", true);
+        RCLCPP_INFO(this->get_logger(), "\tEnable covariance smoothing: %d", enable_covariance_smoothing_);
+        
+        covariance_smoothing_alpha_ = declare_parameter<double>("adaptive_covariance.smoothing_alpha", 0.3);
+        RCLCPP_INFO(this->get_logger(), "\tCovariance smoothing alpha: %.2f", covariance_smoothing_alpha_);
+    }
 
     config.max_range = declare_parameter<double>("data.max_range", config.max_range);
     RCLCPP_INFO(this->get_logger(), "\tMax range: %.2f", config.max_range);
@@ -158,6 +204,9 @@ void OdometryServer::initializeParameters(kiss_icp::pipeline::KISSConfig &config
 }
 
 void OdometryServer::RegisterFrame(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &msg) {
+    if (frames_count_++ % process_each_x_frame_ != 0) {
+        return;
+    }
     const auto cloud_frame_id = msg->header.frame_id;
     const auto points = PointCloud2ToEigen(msg);
     const auto timestamps = GetTimestamps(msg);
@@ -204,20 +253,106 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
         tf_broadcaster_->sendTransform(transform_msg);
     }
 
-    // publish odometry msg
+    // Get registration quality metrics (only if enabled)
+    size_t num_correspondences = 0;
+    size_t num_source_points = 0;
+    double cov_multiplier = 1.0;
+    
+    if (use_adaptive_covariance_ || metrics_only_mode_) {
+        num_correspondences = kiss_icp_->num_correspondences();
+        num_source_points = kiss_icp_->num_source_points();
+        
+        // Publish metrics for statistical analysis
+        if (metrics_pub_) {
+            kiss_icp::msg::RegistrationMetrics metrics_msg;
+            metrics_msg.num_correspondences = num_correspondences;
+            metrics_msg.num_source_points = num_source_points;
+            metrics_pub_->publish(metrics_msg);
+        }
+        
+        // Compute multiplier (will be 1.0 if metrics_only_mode is true)
+        cov_multiplier = computeCovarianceMultiplier(num_correspondences, num_source_points);
+    }
+    
+    // Publish odometry msg with adaptive covariance
     nav_msgs::msg::Odometry odom_msg;
     odom_msg.header.stamp = header.stamp;
     odom_msg.header.frame_id = lidar_odom_frame_;
     odom_msg.child_frame_id = moving_frame;
     odom_msg.pose.pose = tf2::sophusToPose(pose);
     odom_msg.pose.covariance.fill(0.0);
-    odom_msg.pose.covariance[0] = position_covariance_;
-    odom_msg.pose.covariance[7] = position_covariance_;
-    odom_msg.pose.covariance[14] = position_covariance_;
-    odom_msg.pose.covariance[21] = orientation_covariance_;
-    odom_msg.pose.covariance[28] = orientation_covariance_;
-    odom_msg.pose.covariance[35] = orientation_covariance_;
+    
+    // Apply multiplier (will be 1.0 if disabled)
+    double adaptive_pos_cov = position_covariance_ * cov_multiplier;
+    double adaptive_orient_cov = orientation_covariance_ * cov_multiplier;
+    
+    odom_msg.pose.covariance[0] = adaptive_pos_cov;    // x
+    odom_msg.pose.covariance[7] = adaptive_pos_cov;     // y
+    odom_msg.pose.covariance[14] = adaptive_pos_cov;    // z
+    odom_msg.pose.covariance[21] = adaptive_orient_cov; // roll
+    odom_msg.pose.covariance[28] = adaptive_orient_cov; // pitch
+    odom_msg.pose.covariance[35] = adaptive_orient_cov; // yaw
+    
+    // Optional logging for debugging (only when enabled)
+    if (use_adaptive_covariance_ || metrics_only_mode_) {
+        RCLCPP_DEBUG(get_logger(), 
+                     "Metrics: corr=%zu/%zu (%.1f%%), mult=%.2fx, pos_cov=%.3f, orient_cov=%.3f%s",
+                     num_correspondences, num_source_points,
+                     100.0 * num_correspondences / std::max(size_t(1), num_source_points),
+                     cov_multiplier, adaptive_pos_cov, adaptive_orient_cov,
+                     metrics_only_mode_ ? " [METRICS-ONLY]" : "");
+    }
+    
     odom_publisher_->publish(std::move(odom_msg));
+}
+
+double OdometryServer::computeCovarianceMultiplier(size_t num_correspondences, 
+                                                    size_t num_source_points) {
+    // If metrics_only_mode is enabled, always return 1.0 (fixed covariance)
+    if (metrics_only_mode_) {
+        return 1.0;
+    }
+    
+    // If adaptive covariance is disabled, return 1.0 (no change)
+    // Note: use_adaptive_covariance_ controls both the ROS parameter and the internal metrics collection
+    if (!use_adaptive_covariance_) {
+        return 1.0;
+    }
+    
+    if (num_source_points == 0) {
+        return max_covariance_multiplier_;  // Worst case
+    }
+    
+    // Inlier ratio: how many source points actually matched, in [0, 1]
+    const double inlier_ratio = static_cast<double>(num_correspondences) /
+                                static_cast<double>(num_source_points);
+
+    // Absolute correspondences quality: how many inliers vs expected minimum
+    double correspondence_quality = static_cast<double>(num_correspondences) / nominal_keypoint_count_ * min_keypoint_ratio_;
+
+    // Clamp to [0, 1]
+    correspondence_quality = std::clamp(correspondence_quality, 0.0, 1.0);
+
+    // 4. Combine inlier ratio + absolute quality into a single quality factor
+    //    Simple product: both have to be good to get a high score.
+    double quality_factor = correspondence_quality * inlier_ratio;
+
+    // Safety clamp
+    quality_factor = std::clamp(quality_factor, 0.0, 1.0);
+
+    // 5. Map quality [0,1] -> multiplier [1, max_covariance_multiplier_]
+    //    Qubic mapping.
+    const double error = 1.0 - quality_factor;      // in [0, 1]
+    double multiplier = 1.0 + (max_covariance_multiplier_ - 1.0) * std::pow(error, 3);
+
+    // 6. Optional exponential smoothing to reduce jitter frame-to-frame
+    if (enable_covariance_smoothing_) {
+        smoothed_covariance_multiplier_ = covariance_smoothing_alpha_ * multiplier +
+            (1.0 - covariance_smoothing_alpha_) * smoothed_covariance_multiplier_;
+        multiplier = smoothed_covariance_multiplier_;
+    }
+
+    return multiplier;
 }
 
 void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> &frame,

--- a/ros/src/OdometryServer.hpp
+++ b/ros/src/OdometryServer.hpp
@@ -35,6 +35,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <std_srvs/srv/empty.hpp>
+#include <kiss_icp/msg/registration_metrics.hpp>
 #include <string>
 
 namespace kiss_icp_ros {
@@ -74,12 +75,17 @@ private:
 
     /// Data subscribers.
     rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_sub_;
+    size_t frames_count_ {};
+    int process_each_x_frame_ = 1;
 
     /// Data publishers.
     rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_publisher_;
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr frame_publisher_;
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr kpoints_publisher_;
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr map_publisher_;
+    
+    /// Metrics publisher (for statistical analysis)
+    rclcpp::Publisher<kiss_icp::msg::RegistrationMetrics>::SharedPtr metrics_pub_;
 
     /// Service servers.
     rclcpp::Service<std_srvs::srv::Empty>::SharedPtr reset_service_;
@@ -94,6 +100,21 @@ private:
     /// Covariance diagonal
     double position_covariance_;
     double orientation_covariance_;
+    
+    /// Adaptive covariance parameters
+    bool use_adaptive_covariance_;
+    bool metrics_only_mode_;             // Collect metrics but publish fixed covariance
+    double nominal_keypoint_count_;      // Expected keypoints in good conditions
+    double min_keypoint_ratio_;          // Below this ratio, start increasing covariance
+    double max_covariance_multiplier_;   // Maximum inflation factor
+    bool enable_covariance_smoothing_;
+    double covariance_smoothing_alpha_;  // Exponential smoothing factor
+    
+    /// State for smoothing
+    double smoothed_covariance_multiplier_{1.0};
+    
+    /// Helper method to compute adaptive covariance multiplier
+    double computeCovarianceMultiplier(size_t num_correspondences, size_t num_source_points);
 };
 
 }  // namespace kiss_icp_ros


### PR DESCRIPTION
- based on number of keypoints vs. nominal number of keypoints
- based on number of correspondences vs. number of keypoints
- added toggle for forwarding and publishing these metrics in ROS2
- nominal keypoints must be configured prior to use of adaptive covariance