### PR TITLE
Optimize by removing extra loop and using emplace

### DIFF
--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -98,7 +98,7 @@ LinearSystem BuildLinearSystem(const Correspondences &correspondences, const dou
     };
 
     using correspondence_iterator = Correspondences::const_iterator;
-    const auto &[JTJ, JTr] = tbb::parallel_reduce(
+    const auto linear_system = tbb::parallel_reduce(
         // Range
         tbb::blocked_range<correspondence_iterator>{correspondences.cbegin(),
                                                     correspondences.cend()},
@@ -117,7 +117,7 @@ LinearSystem BuildLinearSystem(const Correspondences &correspondences, const dou
         // 2nd Lambda: Parallel reduction of the private Jacboians
         sum_linear_systems);
 
-    return {JTJ, JTr};
+    return linear_system;
 }
 }  // namespace
 

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -66,7 +66,7 @@ std::tuple<Eigen::Vector3d, double> VoxelHashMap::GetClosestNeighbor(
             }
         }
     });
-    return std::make_tuple(closest_neighbor, closest_distance);
+    return {closest_neighbor, closest_distance};
 }
 
 std::vector<Eigen::Vector3d> VoxelHashMap::Pointcloud() const {
@@ -87,11 +87,28 @@ void VoxelHashMap::Update(const std::vector<Eigen::Vector3d> &points,
 }
 
 void VoxelHashMap::Update(const std::vector<Eigen::Vector3d> &points, const Sophus::SE3d &pose) {
-    std::vector<Eigen::Vector3d> points_transformed(points.size());
-    std::transform(points.cbegin(), points.cend(), points_transformed.begin(),
-                   [&](const auto &point) { return pose * point; });
-    const Eigen::Vector3d &origin = pose.translation();
-    Update(points_transformed, origin);
+    const double map_resolution = std::sqrt(voxel_size_ * voxel_size_ / max_points_per_voxel_);
+    std::for_each(points.cbegin(), points.cend(), [&](const auto &point) {
+        const Eigen::Vector3d transformed_point = pose * point;
+        const auto voxel = PointToVoxel(transformed_point, voxel_size_);
+        auto search = map_.find(voxel);
+        if (search != map_.end()) {
+            auto &voxel_points = search.value();
+            if (voxel_points.size() == max_points_per_voxel_ ||
+                std::any_of(voxel_points.cbegin(), voxel_points.cend(),
+                            [&](const auto &voxel_point) {
+                                return (voxel_point - transformed_point).norm() < map_resolution;
+                            })) {
+                return;
+            }
+            voxel_points.emplace_back(transformed_point);
+        } else {
+            std::vector<Eigen::Vector3d> voxel_points;
+            voxel_points.reserve(max_points_per_voxel_);
+            voxel_points.emplace_back(transformed_point);
+            map_.emplace(voxel, std::move(voxel_points));
+        }
+    });
 }
 
 void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
@@ -113,7 +130,7 @@ void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
             std::vector<Eigen::Vector3d> voxel_points;
             voxel_points.reserve(max_points_per_voxel_);
             voxel_points.emplace_back(point);
-            map_.insert({voxel, std::move(voxel_points)});
+            map_.emplace(voxel, std::move(voxel_points));
         }
     });
 }

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -109,6 +109,7 @@ void VoxelHashMap::Update(const std::vector<Eigen::Vector3d> &points, const Soph
             map_.emplace(voxel, std::move(voxel_points));
         }
     });
+    RemovePointsFarFromLocation(pose.translation());
 }
 
 void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {

--- a/cpp/kiss_icp/core/VoxelUtils.cpp
+++ b/cpp/kiss_icp/core/VoxelUtils.cpp
@@ -10,7 +10,7 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
     grid.reserve(frame.size());
     std::for_each(frame.cbegin(), frame.cend(), [&](const auto &point) {
         const auto voxel = PointToVoxel(point, voxel_size);
-        if (!grid.contains(voxel)) grid.insert({voxel, point});
+        if (!grid.contains(voxel)) grid.emplace(voxel, point);
     });
     std::vector<Eigen::Vector3d> frame_dowsampled;
     frame_dowsampled.reserve(grid.size());


### PR DESCRIPTION
This pull request mainly refactors `Update` function in the `VoxelHashMap` to improve code efficiency in how voxel maps are updated.

* Refactored `VoxelHashMap::Update` to transform and insert points into the voxel map in-place, avoiding creation of an intermediate transformed points vector and using `emplace` for more efficient map insertion.
* Changed `VoxelHashMap::AddPoints` and `VoxelDownsample` to use `emplace` instead of `insert` for more efficient and concise map population.
* Simplified return statements in `VoxelHashMap::GetClosestNeighbor` and `BuildLinearSystem`