### PR TITLE
fix ouster dataloader

### DIFF
--- a/python/kiss_icp/datasets/ouster.py
+++ b/python/kiss_icp/datasets/ouster.py
@@ -65,7 +65,7 @@ class OusterDataloader:
         """
 
         try:
-            from ouster.sdk import client, open_source
+            from ouster.sdk import core, open_source
         except ImportError:
             print(f'ouster-sdk is not installed on your system, run "pip install ouster-sdk"')
             exit(1)
@@ -80,12 +80,12 @@ class OusterDataloader:
 
         # since we import ouster-sdk's client module locally, we keep reference
         # to it locally as well
-        self._client = client
+        self._client = core.client
 
         self.data_dir = os.path.dirname(data_dir)
 
         # lookup table for 2D range image projection to a 3D point cloud
-        self._xyz_lut = client.XYZLut(source.metadata)
+        self._xyz_lut = core.XYZLut(source.metadata)
 
         self._pcap_file = str(data_dir)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 all = [
     "open3d>=0.16",
     "polyscope>=2.4.0",
-    "ouster-sdk>=0.11",
+    "ouster-sdk>=0.15.0",
     "pyntcloud",
     "PyYAML",
     "trimesh",


### PR DESCRIPTION
This pull request updates the Ouster SDK integration in the `kiss_icp` dataset loader to support the latest API changes and ensures compatibility with newer versions. The most important changes are:

**Ouster SDK API updates:**

* Updated imports in `python/kiss_icp/datasets/ouster.py` to use `core` instead of `client` from the `ouster.sdk` package, reflecting upstream changes in the SDK API.
* Updated references to `client` classes and methods to use their new locations under `core` (e.g., `core.client`, `core.XYZLut`) in `python/kiss_icp/datasets/ouster.py`.

**Dependency version bump:**

* Increased the minimum required version of `ouster-sdk` from `0.11` to `0.15.0` in `python/pyproject.toml` to ensure compatibility with the new API usage.