### PR TITLE
Fix PointField datatype lookup and add multi-file MCAP directory support

### DIFF
--- a/python/kiss_icp/datasets/mcap.py
+++ b/python/kiss_icp/datasets/mcap.py
@@ -20,7 +20,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import glob
 import os
+import re
 import sys
 
 import numpy as np
@@ -28,31 +30,49 @@ import numpy as np
 
 class McapDataloader:
     def __init__(self, data_dir: str, topic: str, *_, **__):
-        """Standalone .mcap dataloader withouth any ROS distribution."""
+        """Standalone .mcap dataloader without any ROS distribution.
+
+        Accepts either a single .mcap file or a directory containing multiple
+        .mcap files. When a directory is given, all .mcap files are read in
+        chronological order determined by the first message timestamp on the
+        requested topic. If timestamps cannot be read from a file (e.g. the
+        topic is absent), the loader falls back to natural filename order
+        (i.e. run_1, run_2, ..., run_10 rather than lexicographic order).
+        """
         # Conditional imports to avoid injecting dependencies for non mcap users
         try:
             from mcap.reader import make_reader
             from mcap_ros2.reader import read_ros2_messages
-        except ImportError as e:
+        except ImportError:
             print("mcap plugins not installed: 'pip install mcap-ros2-support'")
             exit(1)
 
         from kiss_icp.tools.point_cloud2 import read_point_cloud
 
-        # we expect `data_dir` param to be a path to the .mcap file, so rename for clarity
-        assert os.path.isfile(data_dir), "mcap dataloader expects an existing MCAP file"
-        self.sequence_id = os.path.basename(data_dir).split(".")[0]
-        self.mcap_file = str(data_dir)
-
         self.make_reader = make_reader
         self.read_ros2_messages = read_ros2_messages
         self.read_point_cloud = read_point_cloud
 
-        self.bag = self.make_reader(open(self.mcap_file, "rb"))
+        if os.path.isdir(data_dir):
+            self.mcap_files = self._collect_files(data_dir, topic)
+            self.sequence_id = os.path.basename(str(data_dir).rstrip("/"))
+        elif os.path.isfile(data_dir):
+            self.mcap_files = [str(data_dir)]
+            self.sequence_id = os.path.basename(str(data_dir)).split(".")[0]
+        else:
+            raise FileNotFoundError(
+                f"mcap dataloader expects an existing .mcap file or a directory, got: {data_dir}"
+            )
+
+        # Open the first file to validate the topic and build the summary used
+        # by check_topic(). For multi-file datasets the summary of the first
+        # file is sufficient because all files share the same schema/channel
+        # layout when recorded by a single ROS2 session.
+        self.bag = self.make_reader(open(self.mcap_files[0], "rb"))
         self.summary = self.bag.get_summary()
         self.topic = self.check_topic(topic)
         self.n_scans = self._get_n_scans()
-        self.msgs = self.read_ros2_messages(self.mcap_file, topics=[self.topic])
+        self.msgs = self._iter_msgs()
         self.timestamps = []
         self.use_global_visualizer = True
 
@@ -68,20 +88,98 @@ class McapDataloader:
     def __len__(self):
         return self.n_scans
 
-    def _get_n_scans(self) -> int:
-        return sum(
-            count
-            for (id, count) in self.summary.statistics.channel_message_counts.items()
-            if self.summary.channels[id].topic == self.topic
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _collect_files(self, data_dir: str, topic: str) -> list:
+        """Return .mcap files in *data_dir* sorted by first message timestamp.
+
+        Falls back to natural filename order when the timestamp cannot be read
+        from any file (e.g. the requested topic is not present in that file).
+        Natural sort treats embedded numbers numerically so that run_10 comes
+        after run_9 rather than after run_1.
+        """
+
+        def natural_sort_key(path: str):
+            return [
+                int(part) if part.isdigit() else part.lower()
+                for part in re.split(r"(\d+)", path)
+            ]
+
+        candidates = sorted(
+            glob.glob(os.path.join(str(data_dir), "*.mcap")),
+            key=natural_sort_key,
         )
+        assert len(candidates) > 0, f"No .mcap files found in directory: {data_dir}"
+
+        def first_log_time(filepath: str):
+            """Return the log_time (ns) of the first message on *topic*, or None."""
+            try:
+                with open(filepath, "rb") as f:
+                    reader = self.make_reader(f)
+                    for _schema, channel, message in reader.iter_messages(topics=[topic]):
+                        if channel.topic == topic:
+                            return message.log_time
+                # Topic not present in this file
+                return None
+            except Exception:
+                return None
+
+        log_times = [first_log_time(f) for f in candidates]
+
+        if all(t is not None for t in log_times):
+            ordered = [f for _, f in sorted(zip(log_times, candidates))]
+            sort_method = "timestamp"
+        else:
+            missing = [
+                os.path.basename(f) for f, t in zip(candidates, log_times) if t is None
+            ]
+            print(
+                f"[McapDataloader] WARNING: could not read timestamps from "
+                f"{missing}. Falling back to natural filename order."
+            )
+            ordered = candidates
+            sort_method = "filename (fallback)"
+
+        print(
+            f"[McapDataloader] Reading {len(ordered)} file(s) from '{data_dir}' "
+            f"(sorted by {sort_method}):"
+        )
+        for f in ordered:
+            print(f"  {os.path.basename(f)}")
+
+        return ordered
+
+    def _get_n_scans(self) -> int:
+        """Count total PointCloud2 messages across all files for this topic."""
+        total = 0
+        for mcap_file in self.mcap_files:
+            with open(mcap_file, "rb") as f:
+                summary = self.make_reader(f).get_summary()
+            total += sum(
+                count
+                for channel_id, count in summary.statistics.channel_message_counts.items()
+                if summary.channels[channel_id].topic == self.topic
+            )
+        return total
+
+    def _iter_msgs(self):
+        """Yield messages from all files sequentially."""
+        for mcap_file in self.mcap_files:
+            yield from self.read_ros2_messages(mcap_file, topics=[self.topic])
 
     def reset(self):
         self.timestamps = []
-        self.bag = self.make_reader(open(self.mcap_file, "rb"))
-        self.msgs = self.read_ros2_messages(self.mcap_file, topics=[self.topic])
+        self.bag = self.make_reader(open(self.mcap_files[0], "rb"))
+        self.msgs = self._iter_msgs()
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
 
     @staticmethod
-    def stamp_to_sec(stamp):
+    def stamp_to_sec(stamp) -> float:
         return stamp.sec + float(stamp.nanosec) / 1e9
 
     def get_frames_timestamps(self) -> list:
@@ -110,20 +208,18 @@ class McapDataloader:
 
         if topic and topic in point_cloud_topics:
             return topic
-        # when user specified the topic check that exists
         if topic and topic not in point_cloud_topics:
             print(
-                f'[ERROR] Dataset does not containg any msg with the topic name "{topic}". '
+                f'[ERROR] Dataset does not contain any msg with the topic name "{topic}". '
                 "Please select one of the following topics with the --topic flag"
             )
             print_available_topics_and_exit()
         if len(point_cloud_topics) > 1:
             print(
-                "Multiple sensor_msgs/msg/PointCloud2 topics available."
+                "Multiple sensor_msgs/msg/PointCloud2 topics available. "
                 "Please select one of the following topics with the --topic flag"
             )
             print_available_topics_and_exit()
-
         if len(point_cloud_topics) == 0:
             print("[ERROR] Your dataset does not contain any sensor_msgs/msg/PointCloud2 topic")
         if len(point_cloud_topics) == 1:

--- a/python/kiss_icp/datasets/ncd.py
+++ b/python/kiss_icp/datasets/ncd.py
@@ -72,7 +72,7 @@ class NewerCollegeDataset:
     @staticmethod
     def get_pcd_filenames(scans_folder):
         # cloud_1583836591_182590976.pcd
-        regex = re.compile("^cloud_(\d*_\d*)")
+        regex = re.compile(r"^cloud_(\d*_\d*)")
 
         def get_cloud_timestamp(pcd_filename):
             m = regex.search(pcd_filename)

--- a/python/kiss_icp/tools/point_cloud2.py
+++ b/python/kiss_icp/tools/point_cloud2.py
@@ -38,27 +38,39 @@ import numpy as np
 
 __TIMESTAMP_ATTRIBUTE_NAMES__ = ["time", "timestamps", "timestamp", "t"]
 
-_DATATYPES = {
-    "int8": np.dtype(np.int8),
-    "uint8": np.dtype(np.uint8),
-    "int16": np.dtype(np.int16),
-    "uint16": np.dtype(np.uint16),
-    "int32": np.dtype(np.int32),
-    "uint32": np.dtype(np.uint32),
-    "float32": np.dtype(np.float32),
-    "float64": np.dtype(np.float64),
+# Mapping from the integer datatype codes defined in sensor_msgs/PointField to
+# their numpy equivalents.  The codes are part of the ROS2 message definition:
+#   INT8=1, UINT8=2, INT16=3, UINT16=4, INT32=5, UINT32=6, FLOAT32=7, FLOAT64=8
+#
+# We intentionally use a plain int→name dict instead of inspecting the
+# PointField class attributes at runtime.  The attribute-based approach breaks
+# when the field object comes from mcap_ros2._dynamic, whose classes use
+# __slots__ and therefore return an empty dict from vars().
+_DATATYPE_CODES: dict = {
+    1: "int8",
+    2: "uint8",
+    3: "int16",
+    4: "uint16",
+    5: "int32",
+    6: "uint32",
+    7: "float32",
+    8: "float64",
 }
+
+# Derive the numpy dtype map from the same source of truth so the two dicts
+# can never diverge.
+_DATATYPES: dict = {name: np.dtype(getattr(np, name)) for name in _DATATYPE_CODES.values()}
 
 DUMMY_FIELD_PREFIX = "unnamed_field"
 
 
 def read_point_cloud(msg) -> Tuple[np.ndarray, Union[np.ndarray, None]]:
     """
-    Extract poitns and timestamps from a PointCloud2 message.
+    Extract points and timestamps from a PointCloud2 message.
 
     :return: Tuple of [points, timestamps]
-        points: array of x, y z points, shape: (N, 3)
-        timestamps: array of per-pixel timestamps, shape: (N,)
+        points: array of x, y, z points, shape: (N, 3)
+        timestamps: array of per-point timestamps, shape: (N,)
     """
     field_names = ["x", "y", "z"]
     t_field = None
@@ -134,11 +146,18 @@ def read_points(
 
 
 def get_datatype_name(field) -> str:
-    for attr_name, attr_value in vars(field).items():
-        key_lower = attr_name.lower()
-        if key_lower in _DATATYPES and attr_value == field.datatype:
-            return key_lower
-    raise ValueError(f"Unknown datatype code {field.datatype} for field {vars(field)}")
+    """Return the lowercase numpy dtype name for a PointField datatype code.
+
+    sensor_msgs/PointField stores the datatype as an integer code (1–8).
+    We look it up directly in *_DATATYPE_CODES* instead of inspecting the
+    field object's attributes, because deserialised field objects from
+    mcap_ros2._dynamic use __slots__ and return an empty dict from vars(),
+    which would cause the original attribute-based lookup to always fail.
+    """
+    code = field.datatype
+    if code in _DATATYPE_CODES:
+        return _DATATYPE_CODES[code]
+    raise ValueError(f"Unknown datatype code {code} for field {vars(field)}")
 
 
 def dtype_from_fields(fields: Iterable, point_step: Optional[int] = None) -> np.dtype:


### PR DESCRIPTION
# Fix PointField datatype lookup and add multi-file MCAP directory support

## Summary

This PR fixes two independent bugs in the MCAP dataloader pipeline and adds
support for loading a directory of `.mcap` files in a single run.

---

## Changes

### 1. `kiss_icp/tools/point_cloud2.py` — Fix `get_datatype_name` for dynamic PointField objects

**Problem**

`sensor_msgs/PointField` stores the datatype as an integer code (1–8).
`get_datatype_name()` previously resolved that code by iterating over
`vars(field)` and looking for an attribute whose value matched
`field.datatype`. This works for the standard `sensor_msgs.msg.PointField`
class, but fails silently for field objects deserialised by
`mcap_ros2._dynamic`.

`mcap_ros2._dynamic` generates message classes using `__slots__`, which means
`vars()` always returns an empty dict `{}`. As a result, the loop finds no
matching attribute and raises:

```
ValueError: Unknown datatype code 7 for field {}
```

<details>

<summary>Log output</summary>

```
(.venv) vscode ➜ /workspace/src/kiss-slam-ros2 $ kiss_slam_pipeline --dataloader mcap -t /lidar/points -rs /data/run_01/
  0%|                                                            | 0/100 [00:00<?, ? frames/s]
╭──────────────────────────── Traceback (most recent call last) ─────────────────────────────╮
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_slam/tools/cli.py:15 │
│ 5 in kiss_slam                                                                             │
│                                                                                            │
│   152 │   │   n_scans=n_scans,                                                             │
│   153 │   │   jump=jump,                                                                   │
│   154 │   │   refuse_scans=refuse_scans,                                                   │
│ ❱ 155 │   ).run().print()                                                                  │
│   156                                                                                      │
│   157                                                                                      │
│   158 def run():                                                                           │
│                                                                                            │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_slam/pipeline.py:58  │
│ in run                                                                                     │
│                                                                                            │
│    55 │   │   self.refuse_scans = refuse_scans                                             │
│    56 │                                                                                    │
│    57 │   def run(self):                                                                   │
│ ❱  58 │   │   self._run_pipeline()                                                         │
│    59 │   │   self._run_evaluation()                                                       │
│    60 │   │   self._evaluate_closures()                                                    │
│    61 │   │   self._create_output_dir()                                                    │
│                                                                                            │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_slam/pipeline.py:74  │
│ in _run_pipeline                                                                           │
│                                                                                            │
│    71 │                                                                                    │
│    72 │   def _run_pipeline(self):                                                         │
│    73 │   │   for idx in trange(self._first, self._last, unit=" frames",                   │
│       dynamic_ncols=True):                                                                 │
│ ❱  74 │   │   │   scan, timestamps = self._next(idx)                                       │
│    75 │   │   │   start_time = time.perf_counter_ns()                                      │
│    76 │   │   │   self.kiss_slam.process_scan(scan, timestamps)                            │
│    77 │   │   │   self.times[idx - self._first] = time.perf_counter_ns() - start_time      │
│                                                                                            │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_slam/pipeline.py:147 │
│ in _next                                                                                   │
│                                                                                            │
│   144 │   │   self.pose_graph.write_graph(os.path.join(self.results_dir,                   │
│       "trajectory.g2o"))                                                                   │
│   145 │                                                                                    │
│   146 │   def _next(self, idx):                                                            │
│ ❱ 147 │   │   dataframe = self._dataset[idx]                                               │
│   148 │   │   frame, timestamps = dataframe                                                │
│   149 │   │   return frame, timestamps                                                     │
│   150                                                                                      │
│                                                                                            │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_icp/datasets/mcap.py │
│ :66 in __getitem__                                                                         │
│                                                                                            │
│    63 │   def __getitem__(self, idx):                                                      │
│    64 │   │   msg = next(self.msgs).ros_msg                                                │
│    65 │   │   self.timestamps.append(self.stamp_to_sec(msg.header.stamp))                  │
│ ❱  66 │   │   return self.read_point_cloud(msg)                                            │
│    67 │                                                                                    │
│    68 │   def __len__(self):                                                               │
│    69 │   │   return self.n_scans                                                          │
│                                                                                            │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_icp/tools/point_clou │
│ d2.py:71 in read_point_cloud                                                               │
│                                                                                            │
│    68 │   │   │   field_names.append(t_field)                                              │
│    69 │   │   │   break                                                                    │
│    70 │                                                                                    │
│ ❱  71 │   points_structured = read_points(msg, field_names=field_names)                    │
│    72 │   points = np.column_stack(                                                        │
│    73 │   │   [points_structured["x"], points_structured["y"], points_structured["z"]]     │
│    74 │   )                                                                                │
│                                                                                            │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_icp/tools/point_clou │
│ d2.py:105 in read_points                                                                   │
│                                                                                            │
│   102 │   # Cast bytes to numpy array                                                      │
│   103 │   points = np.ndarray(                                                             │
│   104 │   │   shape=(cloud.width * cloud.height,),                                         │
│ ❱ 105 │   │   dtype=dtype_from_fields(cloud.fields, point_step=cloud.point_step),          │
│   106 │   │   buffer=cloud.data,                                                           │
│   107 │   )                                                                                │
│   108                                                                                      │
│                                                                                            │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_icp/tools/point_clou │
│ d2.py:159 in dtype_from_fields                                                             │
│                                                                                            │
│   156 │   field_datatypes = []                                                             │
│   157 │   for i, field in enumerate(fields):                                               │
│   158 │   │   # Datatype as numpy datatype                                                 │
│ ❱ 159 │   │   datatype = _DATATYPES[get_datatype_name(field)]                              │
│   160 │   │   # Name field                                                                 │
│   161 │   │   if field.name == "":                                                         │
│   162 │   │   │   name = f"{DUMMY_FIELD_PREFIX}_{i}"                                       │
│                                                                                            │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_icp/tools/point_clou │
│ d2.py:141 in get_datatype_name                                                             │
│                                                                                            │
│   138 │   │   key_lower = attr_name.lower()                                                │
│   139 │   │   if key_lower in _DATATYPES and attr_value == field.datatype:                 │
│   140 │   │   │   return key_lower                                                         │
│ ❱ 141 │   raise ValueError(f"Unknown datatype code {field.datatype} for field              │
│       {vars(field)}")                                                                      │
│   142                                                                                      │
│   143                                                                                      │
│   144 def dtype_from_fields(fields: Iterable, point_step: Optional[int] = None) ->         │
│       np.dtype:                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
ValueError: Unknown datatype code 7 for field {}
```

</details>

This affects any `.mcap` file recorded with a `ros2msg`-encoded schema (the
default for ROS2 Humble and later), making the MCAP dataloader completely
unusable without a ROS installation.

**Fix**

Replace the attribute-based lookup with a direct integer→name dict
(`_DATATYPE_CODES`). The dict encodes the eight codes from the
`sensor_msgs/PointField` message definition and is the single source of truth
from which `_DATATYPES` (the numpy dtype map) is also derived, so the two can
never diverge.

```python
# Before – breaks for mcap_ros2._dynamic fields (__slots__, vars() == {})
def get_datatype_name(field) -> str:
    for attr_name, attr_value in vars(field).items():
        key_lower = attr_name.lower()
        if key_lower in _DATATYPES and attr_value == field.datatype:
            return key_lower
    raise ValueError(...)

# After – works for any object that exposes a .datatype integer attribute
_DATATYPE_CODES = {1: "int8", 2: "uint8", ..., 7: "float32", 8: "float64"}
_DATATYPES = {name: np.dtype(getattr(np, name)) for name in _DATATYPE_CODES.values()}

def get_datatype_name(field) -> str:
    if field.datatype in _DATATYPE_CODES:
        return _DATATYPE_CODES[field.datatype]
    raise ValueError(...)
```

---

### 2. `kiss_icp/datasets/mcap.py` — Multi-file directory support

**Problem**

ROS2 bag recorders (e.g. `ros2 bag record`) split recordings into multiple
`.mcap` files once a configurable size or duration threshold is reached. The
previous implementation only accepted a single `.mcap` file, requiring users
to either merge files manually or process them one by one — losing loop
closure detection across file boundaries.

<details>

<summary>Log output</summary>

```log
(.venv) vscode ➜ /workspace/src/kiss-slam-ros2 $ kiss_slam_pipeline --dataloader mcap -t /lidar/points -rs /data/run_01/
╭──────────────────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────────────────╮
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_slam/tools/cli.py:143 in kiss_slam                                          │
│                                                                                                                                                   │
│   140 │   from kiss_slam.pipeline import SlamPipeline                                                                                             │
│   141 │                                                                                                                                           │
│   142 │   SlamPipeline(                                                                                                                           │
│ ❱ 143 │   │   dataset=dataset_factory(                                                                                                            │
│   144 │   │   │   dataloader=dataloader,                                                                                                          │
│   145 │   │   │   data_dir=data,                                                                                                                  │
│   146 │   │   │   sequence=sequence,                                                                                                              │
│                                                                                                                                                   │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_icp/datasets/__init__.py:83 in dataset_factory                              │
│                                                                                                                                                   │
│   80 │   module = importlib.import_module(f".{dataloader}", __name__)                                                                             │
│   81 │   assert hasattr(module, dataloader_type), f"{dataloader_type} is not defined in {module}"                                                 │
│   82 │   dataset = getattr(module, dataloader_type)                                                                                               │
│ ❱ 83 │   return dataset(data_dir=data_dir, *args, **kwargs)                                                                                       │
│   84                                                                                                                                              │
│                                                                                                                                                   │
│ /workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_icp/datasets/mcap.py:43 in __init__                                         │
│                                                                                                                                                   │
│    40 │   │   from kiss_icp.tools.point_cloud2 import read_point_cloud                                                                            │
│    41 │   │                                                                                                                                       │
│    42 │   │   # we expect `data_dir` param to be a path to the .mcap file, so rename for clarity                                                  │
│ ❱  43 │   │   assert os.path.isfile(data_dir), "mcap dataloader expects an existing MCAP file"                                                    │
│    44 │   │   self.sequence_id = os.path.basename(data_dir).split(".")[0]                                                                         │
│    45 │   │   self.mcap_file = str(data_dir)                                                                                                      │
│    46                                                                                                                                             │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
AssertionError: mcap dataloader expects an existing MCAP file
```

</details>

The ROS1 `rosbag` dataloader already supported passing a directory and
processing all bags inside it automatically. This PR brings the same
behaviour to the MCAP dataloader.

**Fix**

`McapDataloader.__init__` now accepts either a path to a single `.mcap` file
(existing behaviour, fully backwards compatible) or a path to a directory.

When a directory is given:

1. **Chronological ordering by first message timestamp** — each file is
   opened briefly to read the `log_time` of its first message on the
   requested topic. Files are then sorted by that timestamp. This is robust
   against arbitrary filename conventions.

2. **Natural filename order as fallback** — if the timestamp cannot be read
   from any file (topic absent, file corrupt, etc.) the loader falls back to
   natural sort order (run_1, run_2, …, run_10 rather than lexicographic
   run_1, run_10, run_2). A warning is printed listing the affected files.

3. **Correct scan count** — `_get_n_scans()` now sums message counts across
   all files.

4. **Sequential streaming** — `_iter_msgs()` (a generator) yields messages
   from each file in order without loading all files into memory at once.

5. **Reset support** — `reset()` rebuilds the iterator from the first file,
   as required by the `refuse_scans` / occupancy grid mapping path in
   `kiss_slam`.

**Usage**

```bash
# Single file (unchanged)
kiss_slam_pipeline --dataloader mcap -t /lidar/points recording.mcap

# Directory (new)
kiss_slam_pipeline --dataloader mcap -t /lidar/points /path/to/recording/
```

Output when a directory is given:
```
[McapDataloader] Reading 5 file(s) from '/path/to/recording/' (sorted by timestamp):
  run_01_0.mcap
  run_01_1.mcap
  run_01_2.mcap
  run_01_3.mcap
  run_01_4.mcap
```

---

### 3. `kiss_icp/datasets/ncd.py` — Fix invalid regex escape sequence

<details>

<summary>Log output</summary>

```
(.venv) vscode ➜ /workspace/src/kiss-slam-ros2 $ kiss_slam_pipeline --dataloader mcap -t /lidar/points -rs /data/run_01/
/workspace/src/kiss-slam-ros2/.venv/lib/python3.12/site-packages/kiss_icp/datasets/ncd.py:75: SyntaxWarning: invalid escape sequence '\d'
  regex = re.compile("^cloud_(\d*_\d*)")
```

</details>

`\d` inside a plain string literal is an invalid escape sequence. Python 3.12
emits a `SyntaxWarning`; future versions will raise a `SyntaxError`. Fixed by
using a raw string: `r"^cloud_(\d*_\d*)"`.

---

## Testing

Tested against a 98-file, ~10 000-scan ROS2 Humble recording from an Ouster
OS1-128 LiDAR (Ouster `sensor_msgs/PointCloud2` layout with non-standard
fields `t`, `reflectivity`, `ring`, `ambient`, `range` and `point_step=48`).

- `get_datatype_name` fix: confirmed the `Unknown datatype code 7` error is
  resolved and all nine fields are parsed correctly.
- Directory support: confirmed all 98 files are discovered, sorted in the
  correct temporal order, and processed as a single continuous sequence.