### PR TITLE
Fix division by zero in deskew when all per-point timestamps are equal

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -32,7 +32,9 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <algorithm>
+#include <cmath>
 #include <functional>
+#include <limits>
 #include <vector>
 
 namespace kiss_icp {
@@ -62,12 +64,13 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
             const auto &[min, max] = std::minmax_element(timestamps.cbegin(), timestamps.cend());
             const double min_time = *min;
             const double max_time = *max;
-            if (max_time == min_time) {
+            const double time_range = max_time - min_time;
+            const double tolerance = std::numeric_limits<double>::epsilon() *
+                                     std::max(std::abs(min_time), std::abs(max_time));
+            if (time_range <= tolerance) {
                 return frame;
             }
-            const auto normalize = [&](const double t) {
-                return (t - min_time) / (max_time - min_time);
-            };
+            const auto normalize = [&](const double t) { return (t - min_time) / time_range; };
             const auto &omega = relative_motion.log();
             std::vector<Eigen::Vector3d> deskewed_frame(frame.size());
             tbb::parallel_for(

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -67,7 +67,8 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
             const double time_range = max_time - min_time;
             const double tolerance = std::numeric_limits<double>::epsilon() *
                                      std::max(std::abs(min_time), std::abs(max_time));
-            if (time_range <= tolerance) {
+            // Comparison is negated on purpose: a non-finite range must also skip deskewing
+            if (!(time_range > tolerance)) {
                 return frame;
             }
             const auto normalize = [&](const double t) { return (t - min_time) / time_range; };

--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -62,6 +62,9 @@ std::vector<Eigen::Vector3d> Preprocessor::Preprocess(const std::vector<Eigen::V
             const auto &[min, max] = std::minmax_element(timestamps.cbegin(), timestamps.cend());
             const double min_time = *min;
             const double max_time = *max;
+            if (max_time == min_time) {
+                return frame;
+            }
             const auto normalize = [&](const double t) {
                 return (t - min_time) / (max_time - min_time);
             };

--- a/python/tests/test_preprocess.py
+++ b/python/tests/test_preprocess.py
@@ -1,0 +1,79 @@
+# MIT License
+#
+# Copyright (c) 2022 Ignacio Vizzo, Tiziano Guadagnino, Benedikt Mersch, Cyrill
+# Stachniss.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import numpy as np
+import pytest
+
+from kiss_icp.preprocess import Preprocessor
+
+# Points far enough from the origin to survive the range filter before and after deskewing
+FRAME = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0], [5.0, 5.0, 5.0]])
+
+# Constant velocity guess used to deskew: 1 meter forward, no rotation
+RELATIVE_MOTION = np.array(
+    [
+        [1.0, 0.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+)
+
+
+def _deskewing_preprocessor() -> Preprocessor:
+    return Preprocessor(max_range=100.0, min_range=0.0, deskew=True, max_num_threads=1)
+
+
+@pytest.mark.parametrize("timestamp", [0.0, 1.0, 1.7e9])
+def test_deskew_is_a_noop_when_all_timestamps_are_equal(timestamp):
+    """Scans where every point shares one timestamp must not normalize by a zero time range."""
+    timestamps = np.full(len(FRAME), timestamp)
+
+    frame = _deskewing_preprocessor().preprocess(FRAME, timestamps, RELATIVE_MOTION)
+
+    np.testing.assert_allclose(frame, FRAME)
+
+
+@pytest.mark.parametrize("timestamp", [1.0, 1.7e9])
+def test_deskew_is_a_noop_when_timestamps_differ_by_one_ulp(timestamp):
+    """A time range below the floating point resolution of the timestamps is not a real range."""
+    timestamps = np.full(len(FRAME), timestamp)
+    timestamps[-1] = np.nextafter(timestamp, np.inf)
+
+    frame = _deskewing_preprocessor().preprocess(FRAME, timestamps, RELATIVE_MOTION)
+
+    np.testing.assert_allclose(frame, FRAME)
+
+
+def test_deskew_is_a_noop_for_a_single_point_scan():
+    frame = _deskewing_preprocessor().preprocess(FRAME[:1], np.array([1.7e9]), RELATIVE_MOTION)
+
+    np.testing.assert_allclose(frame, FRAME[:1])
+
+
+def test_deskew_still_compensates_motion_for_distinct_timestamps():
+    timestamps = np.linspace(1.7e9, 1.7e9 + 0.1, len(FRAME))
+
+    frame = _deskewing_preprocessor().preprocess(FRAME, timestamps, RELATIVE_MOTION)
+
+    assert np.isfinite(frame).all()
+    assert not np.allclose(frame, FRAME)

--- a/ros/src/Utils.hpp
+++ b/ros/src/Utils.hpp
@@ -24,7 +24,9 @@
 
 #include <Eigen/Core>
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <regex>
@@ -111,15 +113,18 @@ inline auto NormalizeTimestamps(const std::vector<double> &timestamps) {
     const auto [min_it, max_it] = std::minmax_element(timestamps.cbegin(), timestamps.cend());
     const double min_timestamp = *min_it;
     const double max_timestamp = *max_it;
+    const double time_range = max_timestamp - min_timestamp;
+    const double tolerance = std::numeric_limits<double>::epsilon() *
+                             std::max(std::abs(min_timestamp), std::abs(max_timestamp));
 
     std::vector<double> timestamps_normalized(timestamps.size());
-    if (max_timestamp == min_timestamp) {
+    if (time_range <= tolerance) {
         std::fill(timestamps_normalized.begin(), timestamps_normalized.end(), 1.0);
         return timestamps_normalized;
     }
     std::transform(timestamps.cbegin(), timestamps.cend(), timestamps_normalized.begin(),
                    [&](const auto &timestamp) {
-                       return (timestamp - min_timestamp) / (max_timestamp - min_timestamp);
+                       return (timestamp - min_timestamp) / time_range;
                    });
     return timestamps_normalized;
 }

--- a/ros/src/Utils.hpp
+++ b/ros/src/Utils.hpp
@@ -118,14 +118,14 @@ inline auto NormalizeTimestamps(const std::vector<double> &timestamps) {
                              std::max(std::abs(min_timestamp), std::abs(max_timestamp));
 
     std::vector<double> timestamps_normalized(timestamps.size());
-    if (time_range <= tolerance) {
+    // Comparison is negated on purpose: a non-finite range must also skip deskewing
+    if (!(time_range > tolerance)) {
+        // Map every point to the end of the sweep, which deskews to the identity
         std::fill(timestamps_normalized.begin(), timestamps_normalized.end(), 1.0);
         return timestamps_normalized;
     }
     std::transform(timestamps.cbegin(), timestamps.cend(), timestamps_normalized.begin(),
-                   [&](const auto &timestamp) {
-                       return (timestamp - min_timestamp) / time_range;
-                   });
+                   [&](const auto &timestamp) { return (timestamp - min_timestamp) / time_range; });
     return timestamps_normalized;
 }
 

--- a/ros/src/Utils.hpp
+++ b/ros/src/Utils.hpp
@@ -113,6 +113,10 @@ inline auto NormalizeTimestamps(const std::vector<double> &timestamps) {
     const double max_timestamp = *max_it;
 
     std::vector<double> timestamps_normalized(timestamps.size());
+    if (max_timestamp == min_timestamp) {
+        std::fill(timestamps_normalized.begin(), timestamps_normalized.end(), 1.0);
+        return timestamps_normalized;
+    }
     std::transform(timestamps.cbegin(), timestamps.cend(), timestamps_normalized.begin(),
                    [&](const auto &timestamp) {
                        return (timestamp - min_timestamp) / (max_timestamp - min_timestamp);


### PR DESCRIPTION
## Summary

- Guard the C++ deskew path (`cpp/kiss_icp/core/Preprocessing.cpp`) so `(t - min) / (max - min)` cannot divide by a zero — or non-finite — time range.
- Apply the same guard to the ROS helper `NormalizeTimestamps` (`ros/src/Utils.hpp`), mapping the degenerate case to `1.0`, i.e. the end of the sweep, which deskews to the identity.
- Add `python/tests/test_preprocess.py` covering the degenerate cases plus a positive control.

## Why

Some LiDAR drivers, and plenty of downstream filters, emit point clouds where every point carries the same timestamp. `Preprocess` then computes `0 / 0` for every stamp.

**The symptom is a hard crash, not silent degradation.** `Sophus::SE3d::exp` on a NaN tangent trips `SOPHUS_ENSURE`, whose default handler calls `std::abort()`. That check is not gated on `NDEBUG` and kiss-icp never defines `SOPHUS_DISABLE_ENSURES`, so a release build, a pip wheel and the ROS node all abort with exit 134:

```
[sophus/so3.hpp:750] SOPHUS_ENSURE failed:
SO3::exp failed! omega: nan nan nan, real: nan, img: nan
```

It fires on the very first frame, too: `last_delta_` is identity there, but `(NaN - 1.0) * 0.0` is still NaN. And `deskew` is on by default in `python/kiss_icp/config/config.py`, `config/basic.yaml`, `config/advanced.yaml` and `ros/config/config.yaml`, so this is not an opt-in path.

The most likely real-world trigger is a `PointCloud2` that declares `t` / `timestamp` / `time` / `time_stamp` but leaves it zero-filled: `GetTimestampField` keys on the field *name* only and never inspects the values. This repo can build exactly such a cloud itself — `CreatePointCloud2Msg(..., timestamp = true)` adds a FLOAT64 `time` field that `FillPointCloud2XYZ` never writes.

Other paths that reach the same place: the `rosbag` / `mcap` dataloaders hand raw timestamps straight to `Preprocess` with no normalization, so a `float32` field carrying absolute epoch seconds collapses an entire sweep to one value (one ULP of `float32` at 1.7e9 is 128 s); and per-firing-column timestamps (`ouster.py` tiles one value per column, by construction) degenerate whenever a CropBox or ROI filter narrows the cloud to a single azimuth. A single-point scan is degenerate for the same reason.

## Why the tolerance is relative

`eps * max(|min_time|, |max_time|)` rather than an absolute constant: the Python path passes raw dataset timestamps through, so the unit may be epoch seconds, nanoseconds, or an already-normalized `[0, 1]`. Scaling by magnitude is the only unit-agnostic choice, and it stays orders of magnitude below any real sweep — `eps * 1.7e9` is about 0.4 µs against a 100 ms scan. `std::abs` is load-bearing: without it a scan whose timestamps are all equal and negative (relative timing centred on zero) produces a negative tolerance and falls straight back into the division.

The comparison is written negated, `!(time_range > tolerance)`, because every comparison against NaN is false — `<=` would let a non-finite range slip past the guard and into `exp`. The guard can also manufacture such a range on its own: all-infinite timestamps give `inf - inf = NaN`. This does not sanitize an interior NaN (`{0, NaN, 1}` yields a valid range of 1, the guard correctly passes, and that one point still aborts); full timestamp sanitization is a separate concern.

## Why both files

`NormalizeTimestamps` produces the NaN *before* `Preprocess` ever runs, and `NaN <= tolerance` is false, so the core guard alone does not cover the ROS path. Filling with `1.0` maps every point to the end of the sweep, which is the identity deskew the core guard also returns, so the two halves agree and nothing is applied twice.

## Tests

`python/tests/test_preprocess.py` covers all-equal timestamps (`0.0`, `1.0`, epoch seconds), a one-ULP spread, a single-point scan, and a positive control asserting a real 0.1 s sweep is still deskewed. `python.yml` already builds the pybind extension and runs `pytest ./python/` on seven OS/arch combinations, so this needs no CI changes.

Against the unpatched code these tests do not fail cleanly — they kill the interpreter, because the abort happens in C++ inside `tbb::parallel_for`:

```
python/tests/test_preprocess.py Fatal Python error: Aborted
  File ".../kiss_icp/preprocess.py", line 46 in preprocess
  File ".../tests/test_preprocess.py", line 51 in test_deskew_is_a_noop_when_all_timestamps_are_equal
PYTEST EXIT=134
```

CI still goes red and names the test. The `ros/src/Utils.hpp` half gets no automated coverage — `ros.yml` runs `colcon build` only, with no `colcon test`.
