### PR TITLE
Remove limiting project to C++

### DIFF
--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 cmake_minimum_required(VERSION 3.16...3.26)
-project(kiss_icp VERSION 1.3.0 LANGUAGES CXX)
+project(kiss_icp VERSION 1.3.0)
 
 set(CMAKE_BUILD_TYPE Release)
 


### PR DESCRIPTION
Hello,

I get the following error when building kiss-icp on a 24.04 ubuntu with ros 2 rolling installed on it. The error does not happen on a ubuntu 24.04 with ros 2 jazzy. Not sure, why the error only appears when rolling is used but there is a fix for it.

Error solved by change:

```
--- stderr: kiss_icp                                                                                                     
CMake Error in CMakeLists.txt:
  No known features for C compiler

  ""

  version .
```

```
--- stderr: kiss_icp                                                                                                          
CMake Error at CMakeLists.txt:54 (target_compile_features):
  target_compile_features no known features for CXX compiler

  ""

  version .
```

Could this be merged or the real cause of the problem be solved?

Best regards,
Haider