### PR TITLE
docs(readme): fix typo in project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <br />
   <br />
 
-[KISS-ICP](https://www.ipb.uni-bonn.de/wp-content/papercite-data/pdf/vizzo2023ral.pdf) is a LiDAR Odometry pipeline that **just works** on most of the cases without tunning any parameter.
+[KISS-ICP](https://www.ipb.uni-bonn.de/wp-content/papercite-data/pdf/vizzo2023ral.pdf) is a LiDAR Odometry pipeline that **just works** on most of the cases without tuning any parameter.
 
   <p align="center">
     <a href="https://user-images.githubusercontent.com/21349875/219626075-d67e9165-31a2-4a1b-8c26-9f04e7d195ec.mp4"><img alt="KISS-ICP Demo" src="https://user-images.githubusercontent.com/21349875/211829074-474bec08-0129-4e34-85e7-62265e44a7de.png"></a>


### PR DESCRIPTION
## Summary

Fix a small typo in the README project description.

## Change

- `tunning` -> `tuning`