### PR TITLE
Optimize local variable usage with std::move

### DIFF
--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -117,7 +117,7 @@ LinearSystem BuildLinearSystem(const Correspondences &correspondences, const dou
         // 2nd Lambda: Parallel reduction of the private Jacboians
         sum_linear_systems);
 
-    return {JTJ, JTr};
+    return {std::move(JTJ), std::move(JTr)};
 }
 }  // namespace
 

--- a/cpp/kiss_icp/core/Registration.cpp
+++ b/cpp/kiss_icp/core/Registration.cpp
@@ -98,7 +98,7 @@ LinearSystem BuildLinearSystem(const Correspondences &correspondences, const dou
     };
 
     using correspondence_iterator = Correspondences::const_iterator;
-    const auto &[JTJ, JTr] = tbb::parallel_reduce(
+    auto [JTJ, JTr] = tbb::parallel_reduce(
         // Range
         tbb::blocked_range<correspondence_iterator>{correspondences.cbegin(),
                                                     correspondences.cend()},

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -113,7 +113,7 @@ void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
             std::vector<Eigen::Vector3d> voxel_points;
             voxel_points.reserve(max_points_per_voxel_);
             voxel_points.emplace_back(point);
-            map_.insert({voxel, std::move(voxel_points)});
+            map_.emplace(voxel, std::move(voxel_points));
         }
     });
 }

--- a/cpp/kiss_icp/core/VoxelUtils.cpp
+++ b/cpp/kiss_icp/core/VoxelUtils.cpp
@@ -9,7 +9,7 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
     tsl::robin_map<Voxel, Eigen::Vector3d> grid;
     grid.reserve(frame.size());
     std::for_each(frame.cbegin(), frame.cend(), [&](const auto &point) {
-        const auto voxel = PointToVoxel(point, voxel_size);
+        auto voxel = PointToVoxel(point, voxel_size);
         if (!grid.contains(voxel)) grid.emplace(std::move(voxel), point);
     });
     std::vector<Eigen::Vector3d> frame_dowsampled;

--- a/cpp/kiss_icp/core/VoxelUtils.cpp
+++ b/cpp/kiss_icp/core/VoxelUtils.cpp
@@ -10,7 +10,7 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
     grid.reserve(frame.size());
     std::for_each(frame.cbegin(), frame.cend(), [&](const auto &point) {
         const auto voxel = PointToVoxel(point, voxel_size);
-        if (!grid.contains(voxel)) grid.insert({voxel, point});
+        if (!grid.contains(voxel)) grid.emplace(std::move(voxel), point);
     });
     std::vector<Eigen::Vector3d> frame_dowsampled;
     frame_dowsampled.reserve(grid.size());

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -64,14 +64,14 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
 
     // Return the (deskew) input raw scan (preprocessed_frame) and the points used for registration
     // (source)
-    return {preprocessed_frame, source};
+    return {std::move(preprocessed_frame), std::move(source)};
 }
 
 KissICP::Vector3dVectorTuple KissICP::Voxelize(const std::vector<Eigen::Vector3d> &frame) const {
     const auto voxel_size = config_.voxel_size;
     const auto frame_downsample = kiss_icp::VoxelDownsample(frame, voxel_size * 0.5);
     const auto source = kiss_icp::VoxelDownsample(frame_downsample, voxel_size * 1.5);
-    return {source, frame_downsample};
+    return {std::move(source), std::move(frame_downsample)};
 }
 void KissICP::Reset() {
     last_pose_ = Sophus::SE3d();

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -35,7 +35,7 @@ namespace kiss_icp::pipeline {
 KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vector3d> &frame,
                                                     const std::vector<double> &timestamps) {
     // Preprocess the input cloud
-    const auto &preprocessed_frame = preprocessor_.Preprocess(frame, timestamps, last_delta_);
+    Vector3dVector preprocessed_frame = preprocessor_.Preprocess(frame, timestamps, last_delta_);
 
     // Voxelize
     const auto &[source, frame_downsample] = Voxelize(preprocessed_frame);
@@ -69,8 +69,8 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
 
 KissICP::Vector3dVectorTuple KissICP::Voxelize(const std::vector<Eigen::Vector3d> &frame) const {
     const auto voxel_size = config_.voxel_size;
-    const auto frame_downsample = kiss_icp::VoxelDownsample(frame, voxel_size * 0.5);
-    const auto source = kiss_icp::VoxelDownsample(frame_downsample, voxel_size * 1.5);
+    Vector3dVector frame_downsample = kiss_icp::VoxelDownsample(frame, voxel_size * 0.5);
+    Vector3dVector source = kiss_icp::VoxelDownsample(frame_downsample, voxel_size * 1.5);
     return {std::move(source), std::move(frame_downsample)};
 }
 void KissICP::Reset() {

--- a/cpp/kiss_icp/pipeline/KissICP.cpp
+++ b/cpp/kiss_icp/pipeline/KissICP.cpp
@@ -38,7 +38,7 @@ KissICP::Vector3dVectorTuple KissICP::RegisterFrame(const std::vector<Eigen::Vec
     Vector3dVector preprocessed_frame = preprocessor_.Preprocess(frame, timestamps, last_delta_);
 
     // Voxelize
-    const auto &[source, frame_downsample] = Voxelize(preprocessed_frame);
+    const auto [source, frame_downsample] = Voxelize(preprocessed_frame);
 
     // Get adaptive_threshold
     const double sigma = adaptive_threshold_.ComputeThreshold();


### PR DESCRIPTION
This pull request introduces several minor optimizations to improve memory efficiency and performance by leveraging move semantics and more efficient container insertion methods in the codebase.

### Performance and Memory Optimizations

* Updated multiple return statements to use `std::move` for returning large objects, reducing unnecessary copies in `RegisterFrame`, `Voxelize`, and `BuildLinearSystem` functions (`KissICP.cpp`, `Registration.cpp`). 
* Replaced `insert` with `emplace` for more efficient insertion in hash maps and unordered maps in `VoxelHashMap::AddPoints` and `VoxelDownsample`, ensuring in-place construction and move semantics (`VoxelHashMap.cpp`, `VoxelUtils.cpp`).

Here is a [QuickBench evaluation](https://quick-bench.com/q/ZIfumVTe-7qUblB76j8CugUQxT0):
<img width="2504" height="990" alt="image" src="https://github.com/user-attachments/assets/b4570ee8-6586-4baa-b128-73ef5ba8dee3" />

When returning individual big heap objects from a function, RVO handles the return efficiently by avoiding a copy.
However, when returning a collection of big heap objects as `std::pair` or `std::tuple`, RVO does not optimize the returns. Therefore an explicit `std::move` makes life easier for the compiler. 