### PR TITLE
fix(odom_server): apply cloud2base transform to local map

### DIFF
--- a/ros/src/OdometryServer.cpp
+++ b/ros/src/OdometryServer.cpp
@@ -226,13 +226,34 @@ void OdometryServer::PublishOdometry(const Sophus::SE3d &kiss_pose,
 void OdometryServer::PublishClouds(const std::vector<Eigen::Vector3d> &frame,
                                    const std::vector<Eigen::Vector3d> &keypoints,
                                    const std_msgs::msg::Header &header) {
-    const auto kiss_map = kiss_icp_->LocalMap();
-
+    // Publish current frame and keypoints (these use the sensor frame, so they are fine)
     frame_publisher_->publish(std::move(EigenToPointCloud2(frame, header)));
     kpoints_publisher_->publish(std::move(EigenToPointCloud2(keypoints, header)));
+
+    // Prepare header for the local map
     auto local_map_header = header;
     local_map_header.frame_id = lidar_odom_frame_;
-    map_publisher_->publish(std::move(EigenToPointCloud2(kiss_map, local_map_header)));
+
+    const auto kiss_map = kiss_icp_->LocalMap();
+    const auto cloud_frame_id = header.frame_id;
+    const auto egocentric_estimation = (base_frame_.empty() || base_frame_ == cloud_frame_id);
+
+    if (egocentric_estimation) {
+        // If no base_link offset is configured, publish raw
+        map_publisher_->publish(std::move(EigenToPointCloud2(kiss_map, local_map_header)));
+    } else {
+        // Transform the map points from the initial sensor frame to the initial base_link frame
+        const Sophus::SE3d cloud2base = LookupTransform(base_frame_, cloud_frame_id, tf2_buffer_);
+        
+        std::vector<Eigen::Vector3d> transformed_map;
+        transformed_map.reserve(kiss_map.size());
+        
+        for (const auto &pt : kiss_map) {
+            transformed_map.push_back(cloud2base * pt);
+        }
+        
+        map_publisher_->publish(std::move(EigenToPointCloud2(transformed_map, local_map_header)));
+    }
 }
 void OdometryServer::ResetService(
     [[maybe_unused]] const std::shared_ptr<std_srvs::srv::Empty::Request> request,


### PR DESCRIPTION
This PR fixes a bug where the local map (kiss/local_map) was misaligned in RViz when using a custom base_frame (like base_link).

Changes:
- Updated PublishClouds to check if a base_frame is configured.
- Applied the cloud2base transform to the local map points before publishing them to lidar_odom_frame_.

Now, the local map correctly aligns with the robot's actual base origin instead of being shifted by the sensor offset.

Before
<img width="894" height="610" alt="Screenshot from 2026-06-15 16-35-55" src="https://github.com/user-attachments/assets/766d5bf8-6c65-44b8-b619-43085733aed1" />

After
<img width="1421" height="698" alt="Screenshot from 2026-06-15 16-48-58" src="https://github.com/user-attachments/assets/5d5ea0e5-a865-4c8d-9e63-2b79ee098a91" />

Tested on ROS2 Jazzy

Closes #506 
