### PR TITLE
Fix wheel builds from source distributions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -18,6 +18,8 @@ jobs:
         run: pipx run build --sdist ${{github.workspace}}/python/
       - name: Move sdist to dist
         run: mkdir -p dist && mv ${{github.workspace}}/python/dist/*.tar.gz dist/
+      - name: Build wheel from sdist
+        run: python -m pip wheel --no-deps --wheel-dir sdist-wheel dist/*.tar.gz
 
       - uses: actions/upload-artifact@v4
         with:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -74,12 +74,11 @@ Homepage = "https://github.com/PRBonn/kiss-icp"
 
 [tool.scikit-build]
 build-dir = "build/{wheel_tag}"
-cmake.verbose = false
-cmake.minimum-version = "3.16"
+build.verbose = false
+cmake.version = ">=3.16"
 editable.mode = "redirect"
 editable.rebuild = true
 editable.verbose = true
-sdist.exclude = ["pybind/"]
 wheel.install-dir = "kiss_icp/pybind/"
 
 [tool.black]


### PR DESCRIPTION
## Problem

The Python source distribution excludes `kiss_icp/pybind`, even though its top-level CMake configuration always enters that directory with `add_subdirectory`.

Builds from a repository checkout succeed because the binding sources are present. Builds from the published source distribution fail during CMake configuration on platforms without a compatible prebuilt wheel. The release workflow did not detect this because it built the source distribution and platform wheels independently from the checkout.

## Approach

- Include the pybind CMake and C++ sources in the source distribution.
- Replace the removed `cmake.minimum-version` and `cmake.verbose` settings with the current `cmake.version` and `build.verbose` scikit-build-core settings.
- Add a release-workflow check that builds a wheel from the generated source distribution, exercising the same artifact users receive from PyPI.

## Validation

Before the change, the generated source distribution omitted `kiss_icp/pybind`, and building a wheel from it failed at `add_subdirectory(kiss_icp/pybind)`.

After the change:

- built the source distribution in an isolated environment with scikit-build-core 1.0.3;
- confirmed that all three pybind build/source files are present in the archive;
- built a macOS arm64 Python 3.14 wheel from that source distribution;
- installed the wheel in a clean environment;
- imported `KissICP` and its compiled native extension;
- ran the CLI version check successfully;
- ran the project test suite: 1 passed;
- ran all configured pre-commit checks successfully.

Fixes #454.
